### PR TITLE
ENH: Various tweaks to new theme style

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -36,10 +36,12 @@
 {% block content %}
 <div id="wrapper" class="container clearfix">
   <div id="header">
-    <img
-    id="header-img"
-    src="{{ pathto('_static/logo400.png', 1) }}" alt="QIIME 2"
-    />
+    <a href="https://docs.qiime2.org">
+      <img
+        id="header-img"
+        src="{{ pathto('_static/logo400.png', 1) }}" alt="QIIME 2"
+      />
+    </a>
   </div>
   <div id="content">
     {% block document %}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -21,6 +21,7 @@
     ga('create', 'UA-86671044-2', 'auto');
     ga('send', 'pageview');
   </script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 {% endblock %}
 
 {# Github Banner #}

--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -50,6 +50,11 @@ div.footer {
     font-size: 11px;
 }
 
+code.docutils.literal {
+    background-color: #f5f5f5;
+    color: #333;
+}
+
 @media screen and (min-width: 992px) {
 
   #github-banner {

--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -23,7 +23,7 @@ h1 {
 }
 
 #sidebar {
-  padding: 15px;
+  padding: 15px 0;
   border-top: 1px dashed #bbb;
 }
 


### PR DESCRIPTION
Docs site tweaks for 2.0.6 site

- [x] https://github.com/qiime2/docs/issues/8 (Resolves #8)
- [x] Use similar styling for inline fixed width font as before (the red text is hard on the eyes)
- [x] Mobile site isn’t working
- [x] Make TOC wider to accommodate lengthy headers
- [x] ⁈ Favicon isn’t working, at least on iOS Safari (need to use the same favicon file as qiime2.org)