### PR TITLE
Use relative link instead of harcoded docs.qiime2.org for logo href

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ html: clean
 	@echo
 	@echo "Run the following command to view the build locally:"
 	@echo
-	@echo "    cd build/html && python -m http.server ; cd -"
+	@echo "cd build/html && python -m http.server ; cd -"
 
 .PHONY: preview
 preview: clean
@@ -45,7 +45,7 @@ preview: clean
 	@echo
 	@echo "Run the following command to view the build locally:"
 	@echo
-	@echo "    cd build/preview && python -m http.server ; cd -"
+	@echo "cd build/preview && python -m http.server ; cd -"
 
 .PHONY: linkcheck
 linkcheck:

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -37,7 +37,7 @@
 {% block content %}
 <div id="wrapper" class="container clearfix">
   <div id="header">
-    <a href="https://docs.qiime2.org">
+    <a href="/">
       <img
         id="header-img"
         src="{{ pathto('_static/logo400.png', 1) }}" alt="QIIME 2"


### PR DESCRIPTION
Also, reformatted Makefile serve command for easier copy/paste.