### PR TITLE
ENH: use explicit .qza/.qzv extension in command outputs

### DIFF
--- a/source/interfaces/artifact-api.rst
+++ b/source/interfaces/artifact-api.rst
@@ -110,6 +110,6 @@ Another powerful feature of QIIME 2 is that you can combine interfaces. For exam
 .. command-block::
    :no-exec:
 
-   qiime diversity alpha-group-significance --i-alpha-diversity oo.qza --m-metadata-file sample-metadata.tsv  --o-visualization oo-group-significance
+   qiime diversity alpha-group-significance --i-alpha-diversity oo.qza --m-metadata-file sample-metadata.tsv  --o-visualization oo-group-significance.qzv
 
 .. _`Jupyter Notebook`: http://jupyter.org/

--- a/source/tutorials/fmt.rst
+++ b/source/tutorials/fmt.rst
@@ -50,11 +50,11 @@ We'll begin by performing quality control on the demultiplexed sequences using `
    qiime dada2 plot-qualities \
      --i-demultiplexed-seqs fmt-tutorial-demux-1-10p.qza \
      --p-n 10 \
-     --o-visualization demux-qual-plots-1
+     --o-visualization demux-qual-plots-1.qzv
    qiime dada2 plot-qualities \
      --i-demultiplexed-seqs fmt-tutorial-demux-2-10p.qza \
      --p-n 10 \
-     --o-visualization demux-qual-plots-2
+     --o-visualization demux-qual-plots-2.qzv
 
 .. question::
    Based on the plots you see in ``demux-qual-plots-1.qzv`` and ``demux-qual-plots-2.qzv``, what values would you choose for ``--p-trunc-len`` and ``--p-trim-left`` in this case? How does these plots compare to those generated in the :doc:`the moving pictures tutorial <moving-pictures>`?
@@ -67,14 +67,14 @@ Here the quality seems relatively low in the first few bases, and seems to decre
      --p-trim-left 10 \
      --p-trunc-len 130 \
      --i-demultiplexed-seqs fmt-tutorial-demux-1-10p.qza \
-     --o-representative-sequences rep-seqs-1 \
-     --o-table table-1
+     --o-representative-sequences rep-seqs-1.qza \
+     --o-table table-1.qza
    qiime dada2 denoise \
      --p-trim-left 10 \
      --p-trunc-len 130 \
      --i-demultiplexed-seqs fmt-tutorial-demux-2-10p.qza \
-     --o-representative-sequences rep-seqs-2 \
-     --o-table table-2
+     --o-representative-sequences rep-seqs-2.qza \
+     --o-table table-2.qza
 
 Merging denoised sequence variant data
 --------------------------------------
@@ -98,7 +98,7 @@ Next, we'll generate a summary of the merged ``FeatureTable[Frequency]`` artifac
 
    qiime feature-table summarize \
      --i-table table.qza \
-     --o-visualization table
+     --o-visualization table.qzv
 
 .. question::
    Based on the information in ``table.qzv``, what value will you choose for the ``--p-sampling-depth`` parameter when you run ``qiime diversity core-metrics``?
@@ -112,7 +112,7 @@ We'll also generate a summary of the merged ``FeatureData[Sequence]`` artifact. 
 
    qiime feature-table tabulate-seqs \
      --i-data rep-seqs.qza \
-     --o-visualization rep-seqs
+     --o-visualization rep-seqs.qzv
 
 Diversity analysis
 ------------------

--- a/source/tutorials/import-sequence-data.rst
+++ b/source/tutorials/import-sequence-data.rst
@@ -58,6 +58,6 @@ Importing data
       --type 'SampleData[SequencesWithQuality]' \
       --input-path casava-18-single-end-demultiplexed \
       --source-format CasavaOneEightSingleLanePerSampleDirFmt \
-      --output-path demux
+      --output-path demux.qza
 
 .. _QIIME 2 Forum: https://forum.qiime2.org

--- a/source/tutorials/import.rst
+++ b/source/tutorials/import.rst
@@ -21,9 +21,7 @@ Next we will use the ``qiime tools import`` command, providing a semantic type o
      --input-path feature-table.biom \
      --type "FeatureTable[Frequency]" \
      --source-format BIOMV100Format \
-     --output-path feature-table
-
-.. note:: We didn't specify a file extension for the output file (``--output-path feature-table``). The command-line interface will automatically append the ``.qza`` file extension (if it isn't present) to output artifacts, and the ``.qzv`` file extension to visualizations.
+     --output-path feature-table.qza
 
 We now have a QIIME 2 artifact called ``feature-table.qza`` that we can start using in QIIME 2 analyses! For example, we can create a summary of the feature table as follows:
 
@@ -31,7 +29,7 @@ We now have a QIIME 2 artifact called ``feature-table.qza`` that we can start us
 
    qiime feature-table summarize \
      --i-table feature-table.qza \
-     --o-visualization table-summary
+     --o-visualization table-summary.qzv
 
 To see what semantic types are available in QIIME 2 and to learn more about them, see the :doc:`semantic types <../semantic-types>` section of our documentation.
 

--- a/source/tutorials/moving-pictures.rst
+++ b/source/tutorials/moving-pictures.rst
@@ -66,7 +66,7 @@ To demultiplex sequences we need to know which barcode sequence is associated wi
       --i-seqs raw-sequences.qza \
       --m-barcodes-file sample-metadata.tsv \
       --m-barcodes-category BarcodeSequence \
-      --o-per-sample-sequences demux
+      --o-per-sample-sequences demux.qza
 
 Sequence quality control
 ------------------------
@@ -83,7 +83,7 @@ The ``dada2 denoise`` method requires two parameters that are used in quality fi
    qiime dada2 plot-qualities \
      --i-demultiplexed-seqs demux.qza \
      --p-n 10 \
-     --o-visualization demux-qual-plots
+     --o-visualization demux-qual-plots.qzv
 
 
 .. note::
@@ -107,19 +107,19 @@ In these plots, the quality of the initial bases seems to be high, so we won't t
      --i-demultiplexed-seqs demux.qza \
      --p-trim-left 0 \
      --p-trunc-len 100 \
-     --o-representative-sequences rep-seqs \
-     --o-table table
+     --o-representative-sequences rep-seqs.qza \
+     --o-table table.qza
 
-After the ``dada2 denoise`` step completes, you'll want to explore the resulting data. You can do this using the following two commands, which will create visual summaries of the data. The ``feature-table summarize`` command will give you information on how many sequences are associated with each sample and with each feature, histograms of those distributions, and some related summary statistics. The ``feature-table view-seq-data`` will provide a mapping of feature IDs to sequences, and provide links to easily BLAST each sequence against the NCBI nt database. The latter visualization will be very useful later in the tutorial, when you want to learn more about specific features that are important in the data set.
+After the ``dada2 denoise`` step completes, you'll want to explore the resulting data. You can do this using the following two commands, which will create visual summaries of the data. The ``feature-table summarize`` command will give you information on how many sequences are associated with each sample and with each feature, histograms of those distributions, and some related summary statistics. The ``feature-table tabulate-seqs`` command will provide a mapping of feature IDs to sequences, and provide links to easily BLAST each sequence against the NCBI nt database. The latter visualization will be very useful later in the tutorial, when you want to learn more about specific features that are important in the data set.
 
 .. command-block::
 
    qiime feature-table summarize \
      --i-table table.qza \
-     --o-visualization table
+     --o-visualization table.qzv
    qiime feature-table tabulate-seqs \
      --i-data rep-seqs.qza \
-     --o-visualization rep-seqs
+     --o-visualization rep-seqs.qzv
 
 Generate a tree for phylogenetic diversity analyses
 ---------------------------------------------------
@@ -132,7 +132,7 @@ First, we perform a multiple sequence alignment of the sequences in our ``Featur
 
    qiime alignment mafft \
      --i-sequences rep-seqs.qza \
-     --o-alignment aligned-rep-seqs
+     --o-alignment aligned-rep-seqs.qza
 
 Next, we mask (or filter) the alignment to remove positions that are highly variable. These positions are generally considered to add noise to a resulting phylogenetic tree.
 
@@ -140,7 +140,7 @@ Next, we mask (or filter) the alignment to remove positions that are highly vari
 
    qiime alignment mask \
      --i-alignment aligned-rep-seqs.qza \
-     --o-masked-alignment masked-aligned-rep-seqs
+     --o-masked-alignment masked-aligned-rep-seqs.qza
 
 Next, we'll apply FastTree to generate a phylogenetic tree from the masked alignment.
 
@@ -148,7 +148,7 @@ Next, we'll apply FastTree to generate a phylogenetic tree from the masked align
 
    qiime phylogeny fasttree \
      --i-alignment masked-aligned-rep-seqs.qza \
-     --o-tree unrooted-tree
+     --o-tree unrooted-tree.qza
 
 The FastTree program creates an unrooted tree, so in the final step in this section we apply midpoint rooting to place the root of the tree at the midpoint of the longest tip-to-tip distance in the unrooted tree.
 
@@ -156,7 +156,7 @@ The FastTree program creates an unrooted tree, so in the final step in this sect
 
    qiime phylogeny midpoint-root \
      --i-tree unrooted-tree.qza \
-     --o-rooted-tree rooted-tree
+     --o-rooted-tree rooted-tree.qza
 
 Alpha and beta diversity analysis
 ---------------------------------
@@ -201,12 +201,12 @@ We'll first test for associations between discrete metadata categories and alpha
    qiime diversity alpha-group-significance \
      --i-alpha-diversity cm1441/faith_pd_vector.qza \
      --m-metadata-file sample-metadata.tsv \
-     --o-visualization cm1441/faith-pd-group-significance
+     --o-visualization cm1441/faith-pd-group-significance.qzv
 
    qiime diversity alpha-group-significance \
      --i-alpha-diversity cm1441/evenness_vector.qza \
      --m-metadata-file sample-metadata.tsv \
-     --o-visualization cm1441/evenness-group-significance
+     --o-visualization cm1441/evenness-group-significance.qzv
 
 .. question::
    What discrete sample metadata categories are most strongly associated with the differences in microbial community **richness**? Are these differences statistically significant?
@@ -221,12 +221,12 @@ Next, we'll test for associations between alpha diversity metrics and continuous
    qiime diversity alpha-correlation \
      --i-alpha-diversity cm1441/faith_pd_vector.qza \
      --m-metadata-file sample-metadata.tsv \
-     --o-visualization cm1441/faith-pd-correlation
+     --o-visualization cm1441/faith-pd-correlation.qzv
 
    qiime diversity alpha-correlation \
      --i-alpha-diversity cm1441/evenness_vector.qza \
      --m-metadata-file sample-metadata.tsv \
-     --o-visualization cm1441/evenness-correlation
+     --o-visualization cm1441/evenness-correlation.qzv
 
 .. question::
    What do you conclude about the associations between continuous sample metadata and the richness and evenness of these samples?
@@ -239,13 +239,13 @@ Next we'll analyze sample composition in the context of discrete metadata using 
      --i-distance-matrix cm1441/unweighted_unifrac_distance_matrix.qza \
      --m-metadata-file sample-metadata.tsv \
      --m-metadata-category BodySite \
-     --o-visualization cm1441/unweighted-unifrac-body-site-significance
+     --o-visualization cm1441/unweighted-unifrac-body-site-significance.qzv
 
    qiime diversity beta-group-significance \
      --i-distance-matrix cm1441/unweighted_unifrac_distance_matrix.qza \
      --m-metadata-file sample-metadata.tsv \
      --m-metadata-category Subject \
-     --o-visualization cm1441/unweighted-unifrac-subject-group-significance
+     --o-visualization cm1441/unweighted-unifrac-subject-group-significance.qzv
 
 .. question::
    Are the associations between subjects and differences in microbial composition statistically significant? How about body sites? What body sites appear to be most different from each other?
@@ -257,12 +257,12 @@ Finally, we'll explore associations between the microbial composition of the sam
    qiime diversity bioenv \
      --i-distance-matrix cm1441/unweighted_unifrac_distance_matrix.qza \
      --m-metadata-file sample-metadata.tsv \
-     --o-visualization cm1441/unweighted-unifrac-bioenv
+     --o-visualization cm1441/unweighted-unifrac-bioenv.qzv
 
    qiime diversity bioenv \
      --i-distance-matrix cm1441/bray_curtis_distance_matrix.qza \
      --m-metadata-file sample-metadata.tsv \
-     --o-visualization cm1441/bray-curtis-bioenv
+     --o-visualization cm1441/bray-curtis-bioenv.qzv
 
 .. question::
    What sample metadata or combinations of sample metadata are most strongly associated with the differences in microbial composition of the samples? How strong are these correlations?
@@ -275,13 +275,13 @@ Finally, ordination is a popular approach for exploring microbial community comp
      --i-pcoa cm1441/unweighted_unifrac_pcoa_results.qza \
      --m-metadata-file sample-metadata.tsv \
      --p-custom-axis DaysSinceExperimentStart \
-     --o-visualization cm1441/unweighted-unifrac-emperor
+     --o-visualization cm1441/unweighted-unifrac-emperor.qzv
 
    qiime emperor plot \
      --i-pcoa cm1441/bray_curtis_pcoa_results.qza \
      --m-metadata-file sample-metadata.tsv \
      --p-custom-axis DaysSinceExperimentStart \
-     --o-visualization cm1441/bray-curtis-emperor
+     --o-visualization cm1441/bray-curtis-emperor.qzv
 
 .. question::
     Do the Emperor plots support the other beta diversity analyses we've performed here? (Hint: Experiment with coloring points by different metadata.)
@@ -303,14 +303,14 @@ In the next sections we'll begin to explore the taxonomic composition of the sam
    qiime feature-classifier classify \
      --i-classifier gg-13-8-99-515-806-nb-classifier.qza \
      --i-reads rep-seqs.qza \
-     --o-classification taxonomy
+     --o-classification taxonomy.qza
 
    qiime taxa tabulate \
      --i-data taxonomy.qza \
-     --o-visualization taxonomy
+     --o-visualization taxonomy.qzv
 
 .. question::
-    Recall that our ``rep-seqs.qzv`` artifact allows you to easily BLAST the sequence associated with each feature against the NCBI nt database. Using that artifact and the ``taxonomy.qzv`` artifact created here, compare the taxonomic assignments with the taxonomy of the best BLAST hit for a few features. How similar are the assignments? If they're dissimilar, at what *taxonomic level* do they begin to differ (e.g., species, genus, family, ...)?
+    Recall that our ``rep-seqs.qzv`` visualization allows you to easily BLAST the sequence associated with each feature against the NCBI nt database. Using that visualization and the ``taxonomy.qzv`` visualization created here, compare the taxonomic assignments with the taxonomy of the best BLAST hit for a few features. How similar are the assignments? If they're dissimilar, at what *taxonomic level* do they begin to differ (e.g., species, genus, family, ...)?
 
 Next, we can view the taxonomic composition of our samples with interactive bar plots. Generate those plots with the following command and then open the visualization.
 
@@ -320,7 +320,7 @@ Next, we can view the taxonomic composition of our samples with interactive bar 
      --i-table table.qza \
      --i-taxonomy taxonomy.qza \
      --m-metadata-file sample-metadata.tsv \
-     --o-visualization taxa-bar-plots
+     --o-visualization taxa-bar-plots.qzv
 
 .. question::
     Visualize the samples at *Level 2* (which corresponds to the phylum level in this analysis), and then sort the samples by BodySite, then by Subject, and then by DaysSinceExperimentStart. What are the dominant phyla in each in BodySite? Do you observe any consistent change across the two subjects between DaysSinceExperimentStart ``0`` and the later timepoints?
@@ -334,13 +334,13 @@ Finally, we can quantify the process of identifying taxa that are differentially
 
    qiime composition add-pseudocount \
      --i-table table.qza \
-     --o-composition-table comp-table
+     --o-composition-table comp-table.qza
 
    qiime composition ancom \
      --i-table comp-table.qza \
      --m-metadata-file sample-metadata.tsv \
      --m-metadata-category BodySite \
-     --o-visualization ancom-BodySite
+     --o-visualization ancom-BodySite.qzv
 
 .. question::
     What features differ in abundance across BodySite? What groups are they most and least abundant in? What are some the taxonomies of some of these features? (To answer that last question you'll need to refer to a visualization that we generated earlier in this tutorial.)
@@ -353,20 +353,20 @@ We're also often interested in performing a differential abundance test at a spe
      --i-table table.qza \
      --i-taxonomy taxonomy.qza \
      --p-level 2 \
-     --o-collapsed-table table-l2
+     --o-collapsed-table table-l2.qza
 
    qiime composition add-pseudocount \
      --i-table table-l2.qza \
-     --o-composition-table comp-table-l2
+     --o-composition-table comp-table-l2.qza
 
    qiime composition ancom \
      --i-table comp-table-l2.qza \
      --m-metadata-file sample-metadata.tsv \
      --m-metadata-category BodySite \
-     --o-visualization l2-ancom-BodySite
+     --o-visualization l2-ancom-BodySite.qzv
 
 .. question::
-    What phyla differ in abundance across BodySite? How does this align with what you observed in the ``taxa-bar-plots.qza`` visualization that was generated above?
+    What phyla differ in abundance across BodySite? How does this align with what you observed in the ``taxa-bar-plots.qzv`` visualization that was generated above?
 
 .. _sample metadata: https://docs.google.com/spreadsheets/d/1_3ZbqCtAYx-9BJYHoWlICkVJ4W_QGMfJRPLedt_0hws/edit?usp=sharing
 .. _Keemei: http://keemei.qiime.org

--- a/source/tutorials/table-filtering.rst
+++ b/source/tutorials/table-filtering.rst
@@ -25,7 +25,7 @@ When filtering samples this can be used, for example, to filter samples whose to
     qiime feature-table filter-samples \
       --i-table table.qza \
       --p-min-frequency 1500 \
-      --o-filtered-table sample-frequency-filtered-table
+      --o-filtered-table sample-frequency-filtered-table.qza
 
 This filter can be applied to the feature axis to remove low abundance features from a table. For example, you can remove all features with a total abundance (summed across all samples) of less than 10 as follows.
 
@@ -33,7 +33,7 @@ This filter can be applied to the feature axis to remove low abundance features 
     qiime feature-table filter-features \
       --i-table table.qza \
       --p-min-frequency 10 \
-      --o-filtered-table feature-frequency-filtered-table
+      --o-filtered-table feature-frequency-filtered-table.qza
 
 Both of these methods can also be applied to filter based on the maximum total frequency using the ``--p-max-frequency``. The ``--p-min-frequency`` and ``--p-max-frequency`` can be combined to filter based on lower and upper limits of total frequency.
 
@@ -48,7 +48,7 @@ This filtering is commonly used for filtering features that show up in only one 
     qiime feature-table filter-features \
       --i-table table.qza \
       --p-min-samples 2 \
-      --o-filtered-table sample-contingency-filtered-table
+      --o-filtered-table sample-contingency-filtered-table.qza
 
 Similarly, samples that contain only a few features could be filtered from a feature table as follows.
 
@@ -56,7 +56,7 @@ Similarly, samples that contain only a few features could be filtered from a fea
     qiime feature-table filter-samples \
       --i-table table.qza \
       --p-min-features 10 \
-      --o-filtered-table feature-contingency-filtered-table
+      --o-filtered-table feature-contingency-filtered-table.qza
 
 Both of these methods can also be applied to filter contingent on the maximum number of features or samples, using the ``--p-max-features`` and ``--p-max-samples`` parameters, and these can optionally be used in combination with ``--p-min-features`` and ``--p-min-samples``.
 
@@ -78,7 +78,7 @@ Then, we'll call the ``filter-samples`` method with the parameter ``--m-sample-m
     qiime feature-table filter-samples \
      --i-table table.qza \
      --m-sample-metadata-file samples-to-keep.tsv \
-     --o-filtered-table index-filtered-table
+     --o-filtered-table index-filtered-table.qza
 
 Metadata-based filtering
 ------------------------
@@ -92,7 +92,7 @@ For example, filtering the table to contain only samples from subject 1 is perfo
       --i-table table.qza \
       --m-sample-metadata-file sample-metadata.tsv \
       --p-where "Subject='subject-1'" \
-      --o-filtered-table subject-1-filtered-table
+      --o-filtered-table subject-1-filtered-table.qza
 
 ``--p-where`` expressions can be combined using the ``AND`` and ``OR`` keywords. Here, the ``--p-where`` parameter is specifying that we want to retain only the samples whose ``Subject`` is ``subject-1`` *and* whose ``BodySite`` is ``gut`` in ``sample-metadata.tsv``. Again, the values ``subject-1`` and ``gut`` are enclosed in single quotes.
 
@@ -101,7 +101,7 @@ For example, filtering the table to contain only samples from subject 1 is perfo
       --i-table table.qza \
       --m-sample-metadata-file sample-metadata.tsv \
       --p-where "Subject='subject-1' AND BodySite='gut'" \
-      --o-filtered-table subject-1-gut-filtered-table
+      --o-filtered-table subject-1-gut-filtered-table.qza
 
 This syntax also supports negating individual clauses of the ``--p-where`` expression (or the whole expression). Here, the ``--p-where`` parameter is specifying that we want to retain only the samples whose ``Subject`` is ``subject-1`` and whose ``BodySite`` is *not* ``gut`` in ``sample-metadata.tsv``.
 
@@ -110,6 +110,6 @@ This syntax also supports negating individual clauses of the ``--p-where`` expre
       --i-table table.qza \
       --m-sample-metadata-file sample-metadata.tsv \
       --p-where "Subject='subject-1' AND NOT BodySite='gut'" \
-      --o-filtered-table subject-1-non-gut-filtered-table
+      --o-filtered-table subject-1-non-gut-filtered-table.qza
 
 .. note:: Currently, the most common metadata-based filtering of features is based on feature taxonomy, such as filtering all features that are annotated as being in a particular genus. This can currently be achieved using ``filter-features`` if taxonomy is provided in a feature metadata file. We are working on adding more direct support for this functionality, which will be made available in a new method of the ``q2-taxa`` plugin. You can track progress on this `here <https://github.com/qiime2/q2-taxa/issues/40>`_.


### PR DESCRIPTION
Tested this locally with `make html`.

Fixes #41.