### PR TITLE
ENH: distance matrix filtering tutorial

### DIFF
--- a/source/tutorials/filtering.rst
+++ b/source/tutorials/filtering.rst
@@ -1,21 +1,26 @@
-Filtering feature tables
-========================
+Filtering data
+==============
 
 .. note:: This guide assumes you have installed QIIME 2 using one of the procedures in the :doc:`install documents <../install/index>`.
 
-.. qiime1-users:: The methods described in this tutorial mirror the functionality in ``filter_samples_from_otu_table.py`` and ``filter_otus_from_otu_table.py``.
+This tutorial describes how to filter data in QIIME 2. The tutorial describes how to filter feature tables and distance matrices, and will be expanded in the future to describe other ways of filtering data in QIIME 2.
 
-This tutorial covers filtering (i.e., removing) samples and features from feature tables. Feature tables have two axes: the sample axis and the feature axis. The filtering operations described in this tutorial are all applicable to the sample axis and the feature axis using the ``filter-samples`` and ``filter-features`` methods, respectively. Both of these methods are implemented in the ``q2-feature-table`` plugin.
+.. qiime1-users:: The methods described in this tutorial mirror the functionality in ``filter_samples_from_otu_table.py``, ``filter_otus_from_otu_table.py``, and ``filter_distance_matrix.py``.
 
-In this document we'll work with the feature table and sample metadata from the :doc:`Moving Pictures tutorial <./moving-pictures>`. As a first step, download both of these files.
+Download the data we'll use in the tutorial. This includes sample metadata, a feature table, and a distance matrix:
 
 .. command-block::
 
     curl -sL "https://docs.google.com/spreadsheets/d/1_3ZbqCtAYx-9BJYHoWlICkVJ4W_QGMfJRPLedt_0hws/export?gid=0&format=tsv" > sample-metadata.tsv
     curl -sLO https://data.qiime2.org/2.0.6/tutorials/filtering-feature-tables/table.qza
+    curl -sLO https://data.qiime2.org/2017.2/tutorials/filtering/distance-matrix.qza
+
+Filtering feature tables
+------------------------
+In this section of the tutorial we'll see how to filter (i.e., remove) samples and features from a feature table. Feature tables have two axes: the sample axis and the feature axis. The filtering operations described in this tutorial are all applicable to the sample axis and the feature axis using the ``filter-samples`` and ``filter-features`` methods, respectively. Both of these methods are implemented in the ``q2-feature-table`` plugin.
 
 Total-frequency-based filtering
--------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Total-frequency-based filtering is used to filter samples or features based on how frequently they are represented in the feature table.
 
@@ -38,7 +43,7 @@ This filter can be applied to the feature axis to remove low abundance features 
 Both of these methods can also be applied to filter based on the maximum total frequency using the ``--p-max-frequency``. The ``--p-min-frequency`` and ``--p-max-frequency`` can be combined to filter based on lower and upper limits of total frequency.
 
 Contingency-based filtering
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Contingency-based filtering is used to filter samples from a table contingent on the number of features they contain, or to filter features from a table contingent on the number of samples they're observed in.
 
@@ -60,8 +65,10 @@ Similarly, samples that contain only a few features could be filtered from a fea
 
 Both of these methods can also be applied to filter contingent on the maximum number of features or samples, using the ``--p-max-features`` and ``--p-max-samples`` parameters, and these can optionally be used in combination with ``--p-min-features`` and ``--p-min-samples``.
 
+.. _index-based-filtering:
+
 Index-based filtering
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 Index-based filtering is used to retain only a user-specified list of samples or features based on their indices (i.e., identifiers). In this case, the user will provide a tab-separated text file as input with the ``--m-sample-metadata-file`` or ``--m-feature-metadata-file`` parameter (for ``filter-samples`` or ``filter-features``, respectively) where the first column in the file contains the indices that should be retained, and the first row contains headers or names for each column. Only the first column in this file will be used, so there are no requirements on subsequent columns (if any are present). As a result, sample or feature metadata files can be used with this parameter. Index-based filtering can be applied as follows to remove samples from a feature table.
 
@@ -80,8 +87,10 @@ Then, we'll call the ``filter-samples`` method with the parameter ``--m-sample-m
      --m-sample-metadata-file samples-to-keep.tsv \
      --o-filtered-table index-filtered-table.qza
 
+.. _metadata-based-filtering:
+
 Metadata-based filtering
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Metadata-based filtering is similar to index-based filtering, except that the list of indices to keep is determined based on metadata rather than being provided by the user directly. This is achieved using the ``--p-where`` parameter in combination with the ``--m-sample-metadata-file`` or ``--m-feature-metadata-file`` parameter. The user provides a description of the samples that should be retained based on their metadata using ``--p-where``, where the syntax for this description is the SQLite `WHERE-clause <https://en.wikipedia.org/wiki/Where_(SQL)>`_ syntax.
 
@@ -113,3 +122,26 @@ This syntax also supports negating individual clauses of the ``--p-where`` expre
       --o-filtered-table subject-1-non-gut-filtered-table.qza
 
 .. note:: Currently, the most common metadata-based filtering of features is based on feature taxonomy, such as filtering all features that are annotated as being in a particular genus. This can currently be achieved using ``filter-features`` if taxonomy is provided in a feature metadata file. We are working on adding more direct support for this functionality, which will be made available in a new method of the ``q2-taxa`` plugin. You can track progress on this `here <https://github.com/qiime2/q2-taxa/issues/40>`_.
+
+Filtering distance matrices
+---------------------------
+In this section of the tutorial we'll see how to filter (i.e., remove) samples from a distance matrix using the ``filter-distance-matrix`` method provided by the ``q2-diversity`` plugin.
+
+.. note:: Filtering distance matrices works the same way as filtering feature tables by indices or sample metadata. The examples provided in this section are brief; please refer to :ref:`index-based-filtering` and :ref:`metadata-based-filtering` above for more details.
+
+A distance matrix can be filtered based on indices. For example, to filter a distance matrix to retain the two samples specified in ``samples-to-keep.tsv`` above (see :ref:`index-based-filtering`):
+
+.. command-block::
+   qiime diversity filter-distance-matrix \
+     --i-distance-matrix distance-matrix.qza \
+     --m-sample-metadata-file samples-to-keep.tsv \
+     --o-filtered-distance-matrix index-filtered-distance-matrix.qza
+
+A distance matrix can also be filtered based on sample metadata. For example, to filter a distance matrix to retain only samples from subject 2:
+
+.. command-block::
+   qiime diversity filter-distance-matrix \
+     --i-distance-matrix distance-matrix.qza \
+     --m-sample-metadata-file sample-metadata.tsv \
+     --p-where "Subject='subject-2'" \
+     --o-filtered-distance-matrix subject-2-filtered-distance-matrix.qza

--- a/source/tutorials/index.rst
+++ b/source/tutorials/index.rst
@@ -10,4 +10,4 @@ Tutorials
    import
    feature-classifier
    import-sequence-data
-   table-filtering
+   filtering


### PR DESCRIPTION
Added examples of filtering distance matrices to the table filtering tutorial. Renamed and restructured tutorial to be more general (there are now sections for feature tables and distance matrices).

New URL will be https://docs.qiime2.org/2017.2/tutorials/filtering/