### PR TITLE
MAINT: use train release version to version docs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -80,8 +80,15 @@ author = 'QIIME 2 development team'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
+# NOTE: QIIME 2's notion of "release" vs. "version" is the opposite of Sphinx.
+# We define "release" (`qiime2.__release__`) as the "train release", which can
+# consist of many "versions" (`qiime2.__version__`) that are all compatible
+# within the release. We chose to interpret "release" and "version" in this
+# manner because `__version__` in Python packages is typically the full
+# version, including patch numbers and pre/post-release tags.
+#
 # The short X.Y version.
-version = qiime2.__version__
+version = qiime2.__release__
 # The full version, including alpha/beta/rc tags.
 release = qiime2.__version__
 

--- a/source/sphinx_extensions/command_block/extension.py
+++ b/source/sphinx_extensions/command_block/extension.py
@@ -215,7 +215,7 @@ class CommandBlockDirective(docutils.parsers.rst.Directive):
         content = []
         if output_paths:
             # TODO it would be nice to not hardcode this.
-            url_prefix = 'https://docs.qiime2.org/%s/' % qiime2.__version__
+            url_prefix = 'https://docs.qiime2.org/%s/' % qiime2.__release__
 
             # TODO it would be cool to format the artifacts/visualizations
             # as tables instead of unordered lists, but will take a little


### PR DESCRIPTION
We want the train release version (i.e. 2017.2) in URLs instead of the exact version (e.g. 2017.2.0).