### PR TITLE
Plugin descriptions

### DIFF
--- a/source/sphinx_extensions/plugin_directory/templates/available.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/available.rst
@@ -6,9 +6,9 @@ QIIME 2 microbiome analysis functionality is made available to users via plugins
 .. toctree::
    :maxdepth: 3
 
-   {% for name, _ in plugins|dictsort %}
-   {% if _.short_description %}
-   {{ name }}: {{ _.short_description }} <{{ name }}/index>
+   {% for name, plugin in plugins|dictsort %}
+   {% if plugin.short_description %}
+   {{ name }}: {{ plugin.short_description }} <{{ name }}/index>
    {% else %}
    {{ name }}/index
    {% endif %}

--- a/source/sphinx_extensions/plugin_directory/templates/available.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/available.rst
@@ -7,5 +7,6 @@ QIIME 2 microbiome analysis functionality is made available to users via plugins
    :maxdepth: 3
 
    {% for name, _ in plugins|dictsort %}
-   {{ name }}/index
+   {{ name }}: {{ _.short_description }} <{{ name }}/index>
    {% endfor %}
+

--- a/source/sphinx_extensions/plugin_directory/templates/available.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/available.rst
@@ -7,6 +7,10 @@ QIIME 2 microbiome analysis functionality is made available to users via plugins
    :maxdepth: 3
 
    {% for name, _ in plugins|dictsort %}
+   {% if _.short_description %}
    {{ name }}: {{ _.short_description }} <{{ name }}/index>
+   {% else %}
+   {{ name }}/index
+   {% endif %}
    {% endfor %}
 

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -6,6 +6,10 @@
    <table class="table plugin-info">
      <tbody>
        <tr>
+         <th scope="row">Description</th>
+         <td>{{ plugin.description|urlize }}</td>
+       </tr>
+       <tr>
          <th scope="row">Version</th>
          <td>{{ plugin.version }}</td>
        </tr>

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -7,7 +7,11 @@
      <tbody>
        <tr>
          <th scope="row">Description</th>
-         <td>{{ plugin.description|urlize }}</td>
+         <td>
+         	{% for line in plugin.description.splitlines() %}
+         	{{ line|urlize }}<br/>
+         	{% endfor %}
+         </td>
        </tr>
        <tr>
          <th scope="row">Version</th>


### PR DESCRIPTION
Added automatic sphinx handling of `description` and `short_description` per issue [#120](https://github.com/qiime2/docs/issues/120#issuecomment-285428117).

See below screenshots:

**Plugins page**
Note that if no `short_description` exists for the plugin then I just show the name of the plugin.  If a short description exists, I append `: short_description` to the title of the item in the `.doctree`.
<img width="1314" alt="plugins_page" src="https://cloud.githubusercontent.com/assets/4683443/23826919/c8ee9aa0-0664-11e7-83b6-c17d2305c726.png">


**Available Plugins page**
Note that the approach taken on the plugins page as described above automatically propagates to this page.
<img width="1318" alt="available_plugins" src="https://cloud.githubusercontent.com/assets/4683443/23826926/e79c9a92-0664-11e7-8e36-fb7a81f0fa85.png">


**feature-table page**
Note the implementation of the `description` parameter in the table of values, per the suggestion in the referenced issue.  Let me know if you'd like this tweaked in any particular way.
<img width="1314" alt="feature-table" src="https://cloud.githubusercontent.com/assets/4683443/23826945/3da86088-0665-11e7-9cd2-75c6b7d8ae1d.png">


**types page**
Currently if no `short_description` exist there is a hard-coded default value which includes the URL.  This is great for the command-line output and is *by design* per our previous conversations on [qiime2](https://github.com/qiime2/qiime2/pull/222), [q2cli](https://github.com/qiime2/q2cli/pull/130#issuecomment-285425486), and [q2-feature-table](https://github.com/qiime2/q2-feature-table/pull/91#event-988543716).  However, it is a bit redundant in this context.  What do you think?  If you'd prefer to just show "No description available" or something, I can fairly easily implement a REGEX to detect this scenario and respond accordingly.
<img width="1316" alt="types" src="https://cloud.githubusercontent.com/assets/4683443/23826936/2070a688-0665-11e7-991e-55612e64d1d3.png">