### PR TITLE
MAINT: remove jinja2 version pin (2.8)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Documentation building requirements.
 Sphinx==1.4.6
-Jinja2==2.8
+Jinja2


### PR DESCRIPTION
The pinned version of jinja2 (2.8) is incompatible with Emperor, which requires jinja2 >= 2.9.