### PR TITLE
DOC: Update text for new Emperor

### DIFF
--- a/source/tutorials/fmt.rst
+++ b/source/tutorials/fmt.rst
@@ -148,7 +148,7 @@ Below are some specific questions to answer about this data, grouped into a few 
 
 #. Microbiota engraftment.
 
-   a. At approximately what week in the study do microbiome samples in individuals who receive treatment appear most similar to FMT donors in terms of unweighted UniFrac distances? (Hint: See the note above about ``qiime emperor plot``. The *color* and *visibility* tabs are also very important in this Emperor plot.)
+   a. At approximately what week in the study do microbiome samples in individuals who receive treatment appear most similar to FMT donors in terms of unweighted UniFrac distances? (Hint: Try plotting the data with Emperor. Pay close attention to the *color* tab and *visibility* menu.)
    #. At approximately what week in the study do microbiome samples in individuals who receive treatment appear most similar to FMT donors in terms of Bray-Curtis distances?
    #. Is this pattern stronger based on unweighted UniFrac or Bray-Curtis distance? Based on how you know about these metrics, what does this suggest to you about what is changing in the microbiome with fecal microbiota transplant? Use the Jaccard and weighted UniFrac distance Emperor plots to help you refine this idea.
 

--- a/source/tutorials/fmt.rst
+++ b/source/tutorials/fmt.rst
@@ -148,7 +148,7 @@ Below are some specific questions to answer about this data, grouped into a few 
 
 #. Microbiota engraftment.
 
-   a. At approximately what week in the study do microbiome samples in individuals who receive treatment appear most similar to FMT donors in terms of unweighted UniFrac distances? (Hint: Try plotting the data with Emperor. Pay close attention to the *color* tab and *visibility* menu.)
+   a. At approximately what week in the study do microbiome samples in individuals who receive treatment appear most similar to FMT donors in terms of unweighted UniFrac distances? (Hint: Try plotting the data with ``qiime emperor plot``. Pay close attention to the *color* tab and *visibility* menu.)
    #. At approximately what week in the study do microbiome samples in individuals who receive treatment appear most similar to FMT donors in terms of Bray-Curtis distances?
    #. Is this pattern stronger based on unweighted UniFrac or Bray-Curtis distance? Based on how you know about these metrics, what does this suggest to you about what is changing in the microbiome with fecal microbiota transplant? Use the Jaccard and weighted UniFrac distance Emperor plots to help you refine this idea.
 

--- a/source/tutorials/moving-pictures.rst
+++ b/source/tutorials/moving-pictures.rst
@@ -303,7 +303,7 @@ Next we'll analyze sample composition in the context of discrete metadata using 
 
 Again, none of the continuous sample metadata that we have for this data set are correlated with sample composition, so we won't test for those associations here. If you're interested in performing those tests, you can use the ``qiime diversity beta-correlation`` and ``qiime diversity bioenv`` commands.
 
-Finally, ordination is a popular approach for exploring microbial community composition in the context of sample metadata. We can use the `Emperor`_ tool to explore principal coordinates (PCoA) plots in the context of sample metadata. PCoA is run as part of the ``core-metrics`` command, so we can generate these plots for unweighted UniFrac and Bray-Curtis as follows. The ``--p-custom-axis`` parameter that we pass here is very useful for exploring temporal data. The resulting plot will contain axes for principal coordinate 1 (labelled ``0``), principal coordinate 2 (labelled ``1``), and days since the experiment start. This is useful for exploring how the samples change over time.
+Finally, ordination is a popular approach for exploring microbial community composition in the context of sample metadata. We can use the `Emperor`_ tool to explore principal coordinates (PCoA) plots in the context of sample metadata. PCoA is run as part of the ``core-metrics`` command, so we can generate these plots for unweighted UniFrac and Bray-Curtis as follows. The ``--p-custom-axis`` parameter that we pass here is very useful for exploring temporal data. The resulting plot will contain axes for principal coordinate 1, principal coordinate 2, and days since the experiment start. This is useful for exploring how the samples change over time.
 
 .. command-block::
 


### PR DESCRIPTION
I updated the `hint` in the FMT tutorial to not refer to a nonexistent note, and updated the Moving Pictures tutorial to reflect the fact that in the [new version of Emperor](https://github.com/qiime2/q2-emperor/pull/39#issuecomment-302795942) the 

> Axes are no longer labeled using numbers (0 (x %), 1 (y %), 2 (z %))

Fixes #149

I also searched all the other tutorials for mentions of "Emperor", "axis", or "axes" , and found nothing, so I think this PR should take care of any issues along those lines.