### PR TITLE
BUG: Fixes #164 for AWS upgrade

### DIFF
--- a/source/upgrade.rst
+++ b/source/upgrade.rst
@@ -64,8 +64,8 @@ Docker
 
        docker pull qiime2/core:2017.6
 
-Amazon AWS
-    If you did not create your AWS instance using one of the :doc:`official QIIME 2 AMIs <install/virtual/aws>`, you should refer  to the Linux (Native Installation) upgrading instructions.
+Amazon AWS (Official QIIME 2 Image)
+    If you did not create your AWS instance using one of the :doc:`official QIIME 2 AMIs <install/virtual/aws>`, you should refer to the Linux (Native Installation) upgrading instructions above.
     Otherwise, in a shell on the remote AWS machine, run the following command:
 
     .. command-block::

--- a/source/upgrade.rst
+++ b/source/upgrade.rst
@@ -65,7 +65,8 @@ Docker
        docker pull qiime2/core:2017.6
 
 Amazon AWS
-    In a shell on the remote AWS machine, run the following command:
+    If you did not create your AWS instance using one of the :doc:`official QIIME 2 AMIs <install/virtual/aws>`, you should refer  to the Linux (Native Installation) upgrading instructions.
+    Otherwise, in a shell on the remote AWS machine, run the following command:
 
     .. command-block::
        :no-exec:


### PR DESCRIPTION
This PR adds a disclaimer to the AWS upgrade instructions informing the user to refer instead to the Linux (Native Installation) instructions if they did not use one of our official AMIs to build their AWS instance.

<img width="937" alt="screenshot 2017-06-27 13 11 51" src="https://user-images.githubusercontent.com/4683443/27607992-a29d2f44-5b3a-11e7-891a-23205d9a722a.png">
