### PR TITLE
MAINT: update to 2017.8

### DIFF
--- a/source/data-resources.rst
+++ b/source/data-resources.rst
@@ -6,21 +6,21 @@ Taxonomy classifiers for use with q2-feature-classifier
 
 .. danger:: Pre-trained classifiers that can be used with ``q2-feature-classifier`` currently present a security risk. If using a pre-trained classifier such as the ones provided here, you should trust the person who trained the classifier and the person who provided you with the qza file. This security risk will be addressed in a future version of ``q2-feature-classifier``.
 
-.. warning:: These classifiers were trained using scikit-learn 0.18.2, and therefore can only be used with scikit-learn 0.18.2. If you are using a native installation of QIIME, before using these classifiers you should run the following to ensure that you are using the correct version of scikit-learn. If you are using a QIIME 2017.7 virtual machine, scikit-learn 0.18.2 will be installed and you do not need to run this command. The scikit-learn version restriction will be relaxed in a future version of ``q2-feature-classifier``.
+.. warning:: These classifiers were trained using scikit-learn 0.19.0, and therefore can only be used with scikit-learn 0.19.0. If you are using a native installation of QIIME, before using these classifiers you should run the following to ensure that you are using the correct version of scikit-learn. If you are using a QIIME 2017.8 virtual machine, scikit-learn 0.19.0 will be installed and you do not need to run this command. The scikit-learn version restriction will be relaxed in a future version of ``q2-feature-classifier``.
 
    .. command-block::
       :no-exec:
 
-      conda install --override-channels -c defaults scikit-learn=0.18.2
+      conda install --override-channels -c defaults scikit-learn=0.19.0
 
 .. note:: Taxonomic classifiers perform best when they are trained based on your specific sample preparation and sequencing parameters, including the primers that were used for amplification and the length of your sequence reads. Therefore in general you should follow the instructions in :doc:`Training feature classifiers with q2-feature-classifier <../tutorials/feature-classifier>` to train your own taxonomic classifiers (for example, from the marker gene reference databases below).
 
 Naive Bayes classifiers trained on:
 
-- `Silva 119 99% OTUs full-length sequences <https://data.qiime2.org/2017.7/common/silva-119-99-nb-classifier.qza>`_ (MD5: ``1f594af234b693f8bc6d4ca3f3b655d3``)
-- `Silva 119 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2017.7/common/silva-119-99-515-806-nb-classifier.qza>`_ (MD5: ``7e1efd787afa57d90d3c634eddd8d4dd``)
-- `Greengenes 13_8 99% OTUs full-length sequences <https://data.qiime2.org/2017.7/common/gg-13-8-99-nb-classifier.qza>`_ (MD5: ``db5e7157b520d6069d56a0c11d995e15``)
-- `Greengenes 13_8 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2017.7/common/gg-13-8-99-515-806-nb-classifier.qza>`_ (MD5: ``5725427470d60535d64e5ed70b21df14``)
+- `Silva 119 99% OTUs full-length sequences <https://data.qiime2.org/2017.8/common/silva-119-99-nb-classifier.qza>`_ (MD5: ``cc19dcda17348990da07154f7e62e570``)
+- `Silva 119 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2017.8/common/silva-119-99-515-806-nb-classifier.qza>`_ (MD5: ``1ba8fb962e2462e59db12eb75243ab4b``)
+- `Greengenes 13_8 99% OTUs full-length sequences <https://data.qiime2.org/2017.8/common/gg-13-8-99-nb-classifier.qza>`_ (MD5: ``dcb6373e12d464e39a247abed3625ae2``)
+- `Greengenes 13_8 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2017.8/common/gg-13-8-99-515-806-nb-classifier.qza>`_ (MD5: ``7c9890eefd4ccc3da7faa515f17b9d9b``)
 
 Marker gene reference databases
 -------------------------------

--- a/source/install/index.rst
+++ b/source/install/index.rst
@@ -11,10 +11,10 @@ QIIME 2 can be installed natively or using virtual machines. The following pages
 
 .. _core-distribution:
 
-QIIME 2 Core 2017.7 distribution
+QIIME 2 Core 2017.8 distribution
 --------------------------------
 
-The QIIME 2 Core 2017.7 distribution includes the QIIME 2 framework, ``q2cli`` (a QIIME 2 command-line interface) and the following plugins:
+The QIIME 2 Core 2017.8 distribution includes the QIIME 2 framework, ``q2cli`` (a QIIME 2 command-line interface) and the following plugins:
 
 - ``q2-alignment``
 - ``q2-composition``
@@ -26,10 +26,12 @@ The QIIME 2 Core 2017.7 distribution includes the QIIME 2 framework, ``q2cli`` (
 - ``q2-feature-classifier``
 - ``q2-feature-table``
 - ``q2-gneiss``
+- ``q2-longitudinal``
 - ``q2-metadata``
 - ``q2-phylogeny``
 - ``q2-quality-filter``
+- ``q2-sample-classifier``
 - ``q2-taxa``
 - ``q2-types``
 
-.. note:: The QIIME 2 Core 2017.7 distribution includes plugins and interfaces that are developed, maintained, tested, and distributed by the QIIME 2 development team. The Core distribution is necessary to run the commands in the :doc:`QIIME 2 tutorials <../tutorials/index>`. If there are additional QIIME 2 plugins or interfaces you would like to install, please consult the relevant package(s) documentation. Other types of distributions may be made available in the future in addition to Core.
+.. note:: The QIIME 2 Core 2017.8 distribution includes plugins and interfaces that are developed, maintained, tested, and distributed by the QIIME 2 development team. The Core distribution is necessary to run the commands in the :doc:`QIIME 2 tutorials <../tutorials/index>`. If there are additional QIIME 2 plugins or interfaces you would like to install, please consult the relevant package(s) documentation. Other types of distributions may be made available in the future in addition to Core.

--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -20,7 +20,7 @@ After installing Miniconda and opening a new terminal, make sure you're running 
 Install QIIME 2 within a ``conda`` environment
 ----------------------------------------------
 
-Once you have Miniconda installed, create a ``conda`` environment and install the QIIME 2 Core 2017.7 distribution within the environment. We **highly** recommend creating a *new* environment specifically for the QIIME 2 release being installed, as there are many required dependencies that you may not want added to an existing environment. You can choose whatever name you'd like for the environment. In this example, we'll name the environment ``qiime2-2017.7`` to indicate what QIIME 2 release is installed (i.e. ``2017.7``).
+Once you have Miniconda installed, create a ``conda`` environment and install the QIIME 2 Core 2017.8 distribution within the environment. We **highly** recommend creating a *new* environment specifically for the QIIME 2 release being installed, as there are many required dependencies that you may not want added to an existing environment. You can choose whatever name you'd like for the environment. In this example, we'll name the environment ``qiime2-2017.8`` to indicate what QIIME 2 release is installed (i.e. ``2017.8``).
 
 
 .. raw:: html
@@ -38,16 +38,16 @@ Once you have Miniconda installed, create a ``conda`` environment and install th
             </p>
          </div>
          <div id="macOS" class="tab-pane fade">
-            <pre>conda create -n qiime2-2017.7 --file https://data.qiime2.org/distro/core/qiime2-2017.7-conda-osx-64.txt</pre>
+            <pre>conda create -n qiime2-2017.8 --file https://data.qiime2.org/distro/core/qiime2-2017.8-conda-osx-64.txt</pre>
          </div>
          <div id="linux" class="tab-pane fade">
-            <pre>conda create -n qiime2-2017.7 --file https://data.qiime2.org/distro/core/qiime2-2017.7-conda-linux-64.txt</pre>
+            <pre>conda create -n qiime2-2017.8 --file https://data.qiime2.org/distro/core/qiime2-2017.8-conda-linux-64.txt</pre>
          </div>
       </div>
    </div>
 
 
-.. tip:: If you receive errors during the installation process, such as ``gfortran`` errors, please ensure you are following the installation instructions that are compatible with your platform. Other errors are often resolved by running ``conda env remove -n qiime2-2017.7`` to remove the failed environments, then running ``conda clean -y --all`` to clean the local conda installation, and finally re-running the installation instructions above.
+.. tip:: If you receive errors during the installation process, such as ``gfortran`` errors, please ensure you are following the installation instructions that are compatible with your platform. Other errors are often resolved by running ``conda env remove -n qiime2-2017.8`` to remove the failed environments, then running ``conda clean -y --all`` to clean the local conda installation, and finally re-running the installation instructions above.
 
 
 Activate the ``conda`` environment
@@ -58,7 +58,7 @@ Now that you have a QIIME 2 environment, activate it using the environment's nam
 .. command-block::
    :no-exec:
 
-   source activate qiime2-2017.7
+   source activate qiime2-2017.8
 
 To deactivate an environment, run ``source deactivate``.
 

--- a/source/install/virtual/docker.rst
+++ b/source/install/virtual/docker.rst
@@ -14,7 +14,7 @@ In a terminal with Docker activated, run:
 .. command-block::
    :no-exec:
 
-   docker pull qiime2/core:2017.7
+   docker pull qiime2/core:2017.8
 
 3. Confirm the installation
 ---------------------------
@@ -24,4 +24,4 @@ Run the following to confirm that the image was successfully fetched.
 .. command-block::
    :no-exec:
 
-   docker run -t -i -v $(pwd):/data qiime2/core:2017.7 qiime
+   docker run -t -i -v $(pwd):/data qiime2/core:2017.8 qiime

--- a/source/install/virtual/virtualbox.rst
+++ b/source/install/virtual/virtualbox.rst
@@ -15,7 +15,7 @@ Please see https://www.virtualbox.org for details on how to install VirtualBox o
 2. Download the QIIME 2 Core VirtualBox Image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please note, this installation document uses some placeholders throughout the following steps. ``X.Y.Z`` represents the version of QIIME 2 (e.g. ``2017.7``), and ``build_number`` represents the build identifier for the VirtualBox image (an internal reference used by the QIIME 2 Developement Team). Please see the `VirtualBox Images`_ download link to get the download URL for the latest image.
+Please note, this installation document uses some placeholders throughout the following steps. ``X.Y.Z`` represents the version of QIIME 2 (e.g. ``2017.8``), and ``build_number`` represents the build identifier for the VirtualBox image (an internal reference used by the QIIME 2 Developement Team). Please see the `VirtualBox Images`_ download link to get the download URL for the latest image.
 
 3. Unzip the file
 ~~~~~~~~~~~~~~~~~

--- a/source/interfaces/q2studio.rst
+++ b/source/interfaces/q2studio.rst
@@ -12,22 +12,22 @@ Launching QIIME 2 Studio requires an active ``conda`` environment with QIIME 2 i
 .. command-block::
    :no-exec:
 
-   source activate qiime2-2017.7
+   source activate qiime2-2017.8
 
-Please note, your ``conda`` environment might have a name other than ``qiime2-2017.7``, if you or your system administrator provided one during :doc:`installation of QIIME 2<../install/index>`.
+Please note, your ``conda`` environment might have a name other than ``qiime2-2017.8``, if you or your system administrator provided one during :doc:`installation of QIIME 2<../install/index>`.
 
 This interface requires that your system has `Node.js`_. We currently require version 5 or later; you can find `installation instructions here <https://nodejs.org/en/download/current/>`__. This dependency will be unnecessary in the future.
 
 Once you have installed ``Node.js >= 5`` you will need to download and extract the interface's source:
 
 .. download::
-   :url: https://codeload.github.com/qiime2/q2studio/zip/2017.7.0
-   :saveas: q2studio-2017.7.0.zip
+   :url: https://codeload.github.com/qiime2/q2studio/zip/2017.8.0
+   :saveas: q2studio-2017.8.0.zip
 
 .. command-block::
 
-   unzip q2studio-2017.7.0.zip && rm q2studio-2017.7.0.zip
-   cd q2studio-2017.7.0
+   unzip q2studio-2017.8.0.zip && rm q2studio-2017.8.0.zip
+   cd q2studio-2017.8.0
 
 Next we need to install it (both as a Python package, and as a Node.js package):
 

--- a/source/tutorials/atacama-soils.rst
+++ b/source/tutorials/atacama-soils.rst
@@ -21,7 +21,7 @@ Start by creating a directory to work in.
 Before starting the analysis, explore the sample metadata to familiarize yourself with the samples used in this study. The `sample metadata`_ is available as a Google Sheet. This ``sample-metadata.tsv`` file is used throughout the rest of the tutorial.
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/sample_metadata.tsv
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 
@@ -35,15 +35,15 @@ Next, you'll download the multiplexed reads. You will download three ``fastq.gz`
    mkdir emp-paired-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/1p/forward.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/1p/forward.fastq.gz
    :saveas: emp-paired-end-sequences/forward.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/1p/reverse.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/1p/reverse.fastq.gz
    :saveas: emp-paired-end-sequences/reverse.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/1p/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/1p/barcodes.fastq.gz
    :saveas: emp-paired-end-sequences/barcodes.fastq.gz
 
 10% subsample data
@@ -56,17 +56,17 @@ Next, you'll download the multiplexed reads. You will download three ``fastq.gz`
 
 .. download::
    :no-exec:
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/10p/forward.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/10p/forward.fastq.gz
    :saveas: emp-paired-end-sequences/forward.fastq.gz
 
 .. download::
    :no-exec:
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/10p/reverse.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/10p/reverse.fastq.gz
    :saveas: emp-paired-end-sequences/reverse.fastq.gz
 
 .. download::
    :no-exec:
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/10p/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/10p/barcodes.fastq.gz
    :saveas: emp-paired-end-sequences/barcodes.fastq.gz
 
 Paired-end read analysis commands
@@ -148,4 +148,4 @@ Acknowledgements
 
 The data used in this tutorial is presented in: *Arid Soil Microbiome: Significant Impacts of Increasing Aridity. Neilson, Califf, Cardona, Copeland, van Treuren, Josephson, Knight, Gilbert, Quade, Caporaso, and Maier. mSystems (under review).*
 
-.. _sample metadata: https://data.qiime2.org/2017.7/tutorials/atacama-soils/sample_metadata
+.. _sample metadata: https://data.qiime2.org/2017.8/tutorials/atacama-soils/sample_metadata

--- a/source/tutorials/exporting.rst
+++ b/source/tutorials/exporting.rst
@@ -17,7 +17,7 @@ Exporting a feature table
 A ``FeatureTable[Frequency]`` artifact will be exported as a `BIOM v2.1.0 formatted file`_.
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/exporting/feature-table.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/exporting/feature-table.qza
    :saveas: feature-table.qza
 
 .. command-block::
@@ -32,7 +32,7 @@ Exporting a phylogenetic tree
 A ``Phylogeny[Unrooted]`` artifact will be exported as a `newick formatted file`_.
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/exporting/unrooted-tree.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/exporting/unrooted-tree.qza
    :saveas: unrooted-tree.qza
 
 .. command-block::

--- a/source/tutorials/feature-classifier.rst
+++ b/source/tutorials/feature-classifier.rst
@@ -21,15 +21,15 @@ Two elements are required for training the classifier: the reference sequences a
 We will also download the representative sequences from the `Moving Pictures`_ tutorial to test our classifier.
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/training-feature-classifiers/85_otus.fasta
+   :url: https://data.qiime2.org/2017.8/tutorials/training-feature-classifiers/85_otus.fasta
    :saveas: 85_otus.fasta
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/training-feature-classifiers/85_otu_taxonomy.txt
+   :url: https://data.qiime2.org/2017.8/tutorials/training-feature-classifiers/85_otu_taxonomy.txt
    :saveas: 85_otu_taxonomy.txt
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/training-feature-classifiers/rep-seqs.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/training-feature-classifiers/rep-seqs.qza
    :saveas: rep-seqs.qza
 
 Next we import these data into QIIME 2 Artifacts. Since the Greengenes reference taxonomy file (:file:`85_otu_taxonomy.txt`) is a tab-separated (TSV) file without a header, we must specify ``HeaderlessTSVTaxonomyFormat`` as the *source format* since the default *source format* requires a header.

--- a/source/tutorials/filtering.rst
+++ b/source/tutorials/filtering.rst
@@ -21,15 +21,15 @@ First, create a directory to work in and change to that directory.
 Download the data we'll use in the tutorial. This includes sample metadata, a feature table, and a distance matrix:
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/moving-pictures/sample_metadata.tsv
+   :url: https://data.qiime2.org/2017.8/tutorials/moving-pictures/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/filtering/table.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/filtering/table.qza
    :saveas: table.qza
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/filtering/distance-matrix.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/filtering/distance-matrix.qza
    :saveas: distance-matrix.qza
 
 Filtering feature tables

--- a/source/tutorials/fmt.rst
+++ b/source/tutorials/fmt.rst
@@ -25,7 +25,7 @@ Create a directory to work in called ``qiime2-fmt-tutorial`` and change to that 
 As in the Moving Pictures study, you should begin your analysis by familiarizing yourself with the sample metadata. You can again access the `sample metadata`_ as a Google Spreadsheet. Notice that there are three tabs in this spreadsheet. This first tab (called sample-metadata) contains all of the clinical metadata.
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/fmt/sample_metadata.tsv
+   :url: https://data.qiime2.org/2017.8/tutorials/fmt/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 Next, download the *demultiplexed sequences* that we'll use in this analysis. To learn how to start a QIIME 2 analysis from fastq-formatted sequence data, see the :doc:`importing data tutorial <importing>`. We'll need to download two sets of demultiplexed sequences, each corresponding to one of the sequencing runs.
@@ -38,23 +38,23 @@ In this tutorial we'll work with a small subsample of the complete sequence data
 
 .. download::
    :no-exec:
-   :url: https://data.qiime2.org/2017.7/tutorials/fmt/fmt-tutorial-demux-1-10p.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/fmt/fmt-tutorial-demux-1-10p.qza
    :saveas: fmt-tutorial-demux-1.qza
 
 .. download::
    :no-exec:
-   :url: https://data.qiime2.org/2017.7/tutorials/fmt/fmt-tutorial-demux-2-10p.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/fmt/fmt-tutorial-demux-2-10p.qza
    :saveas: fmt-tutorial-demux-2.qza
 
 1% subsample data
 ~~~~~~~~~~~~~~~~~
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/fmt/fmt-tutorial-demux-1-1p.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/fmt/fmt-tutorial-demux-1-1p.qza
    :saveas: fmt-tutorial-demux-1.qza
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/fmt/fmt-tutorial-demux-2-1p.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/fmt/fmt-tutorial-demux-2-1p.qza
    :saveas: fmt-tutorial-demux-2.qza
 
 Sequence quality control
@@ -167,5 +167,5 @@ Acknowledgements
 The data in this tutorial was initially presented in: Microbiota Transfer Therapy alters gut ecosystem and improves gastrointestinal and autism symptoms: an open-label study. Dae-Wook Kang, James B. Adams, Ann C. Gregory, Thomas Borody, Lauren Chittick, Alessio Fasano, Alexander Khoruts, Elizabeth Geis, Juan Maldonado, Sharon McDonough-Means, Elena L. Pollard, Simon Roux, Michael J. Sadowsky, Karen Schwarzberg Lipson, Matthew B. Sullivan, J. Gregory Caporaso and Rosa Krajmalnik-Brown. Microbiome (2017) 5:10. DOI: 10.1186/s40168-016-0225-7.
 
 .. _DADA2: https://www.ncbi.nlm.nih.gov/pubmed/27214047
-.. _sample metadata: https://data.qiime2.org/2017.7/tutorials/fmt/sample_metadata
+.. _sample metadata: https://data.qiime2.org/2017.8/tutorials/fmt/sample_metadata
 .. _Fecal Microbiome Transplant study: http://microbiomejournal.biomedcentral.com/articles/10.1186/s40168-016-0225-7

--- a/source/tutorials/gneiss.rst
+++ b/source/tutorials/gneiss.rst
@@ -52,15 +52,15 @@ The datasets required for this tutorial can be found below (to learn how these w
 
 
 .. download::
-   :url: https://forum-qiime2-org.s3-us-west-2.amazonaws.com/original/1X/bf8a54bc13cb9439e7954ece2418fbc6eca96a2f.txt
+   :url: https://data.qiime2.org/2017.8/tutorials/gneiss/sample-metadata.tsv
    :saveas: sample-metadata.tsv
 
 .. download::
-   :url: https://forum-qiime2-org.s3-us-west-2.amazonaws.com/original/1X/95b1df91e3c119ca598e6d98038a20d6e2ee1a84.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/gneiss/table.qza
    :saveas: table.qza
 
 .. download::
-   :url: https://forum-qiime2-org.s3-us-west-2.amazonaws.com/original/1X/c09782e3f38f4f4116996f44b52b8e76e0084104.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/gneiss/taxa.qza
    :saveas: taxa.qza
 
 

--- a/source/tutorials/importing.rst
+++ b/source/tutorials/importing.rst
@@ -38,11 +38,11 @@ Obtaining example data
    mkdir emp-single-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
    :saveas: emp-single-end-sequences/barcodes.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
    :saveas: emp-single-end-sequences/sequences.fastq.gz
 
 Importing data
@@ -71,15 +71,15 @@ Obtaining example data
    mkdir emp-paired-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/1p/forward.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/1p/forward.fastq.gz
    :saveas: emp-paired-end-sequences/forward.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/1p/reverse.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/1p/reverse.fastq.gz
    :saveas: emp-paired-end-sequences/reverse.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/atacama-soils/1p/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/atacama-soils/1p/barcodes.fastq.gz
    :saveas: emp-paired-end-sequences/barcodes.fastq.gz
 
 Importing data
@@ -151,19 +151,19 @@ Obtaining example data
 Since importing data in these four formats is very similar, we'll only provide examples for two of the variants: ``SingleEndFastqManifestPhred33`` and ``PairedEndFastqManifestPhred64``.
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/se-33.zip
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/se-33.zip
    :saveas: se-33.zip
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/se-33-manifest
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/se-33-manifest
    :saveas: se-33-manifest
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/pe-64.zip
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/pe-64.zip
    :saveas: pe-64.zip
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/pe-64-manifest
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/pe-64-manifest
    :saveas: pe-64-manifest
 
 .. command-block::
@@ -204,7 +204,7 @@ Obtaining example data
 **********************
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/casava-18-single-end-demultiplexed.zip
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/casava-18-single-end-demultiplexed.zip
    :saveas: casava-18-single-end-demultiplexed.zip
 
 .. command-block::
@@ -234,7 +234,7 @@ Obtaining example data
 **********************
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/casava-18-paired-end-demultiplexed.zip
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/casava-18-paired-end-demultiplexed.zip
    :saveas: casava-18-paired-end-demultiplexed.zip
 
 .. command-block::
@@ -267,7 +267,7 @@ Obtaining example data
 **********************
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/feature-table-v100.biom
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/feature-table-v100.biom
    :saveas: feature-table-v100.biom
 
 Importing data
@@ -293,7 +293,7 @@ Obtaining example data
 **********************
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/feature-table-v210.biom
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/feature-table-v210.biom
    :saveas: feature-table-v210.biom
 
 Importing data
@@ -319,7 +319,7 @@ Obtaining example data
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/sequences.fna
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/sequences.fna
    :saveas: sequences.fna
 
 Importing data
@@ -344,7 +344,7 @@ Obtaining example data
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/aligned-sequences.fna
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/aligned-sequences.fna
    :saveas: aligned-sequences.fna
 
 Importing data
@@ -369,7 +369,7 @@ Obtaining example data
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/importing/unrooted-tree.tre
+   :url: https://data.qiime2.org/2017.8/tutorials/importing/unrooted-tree.tre
    :saveas: unrooted-tree.tre
 
 Importing data

--- a/source/tutorials/metadata.rst
+++ b/source/tutorials/metadata.rst
@@ -34,7 +34,7 @@ To get started with understanding sample metadata mapping files, download an exa
    cd qiime2-metadata-tutorial
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/moving-pictures/sample_metadata.tsv
+   :url: https://data.qiime2.org/2017.8/tutorials/moving-pictures/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 Since this is a TSV file, it can be opened and edited in a variety of applications, including text editors, Microsoft Excel, and Google Sheets (e.g. if you plan to validate your metadata with Keemei_).
@@ -57,7 +57,7 @@ As eluded to above, QIIME 2 also supports the notion of viewing some artifacts a
 To get started with understanding artifacts as metadata, first download an example artifact:
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/metadata/faith_pd_vector.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/metadata/faith_pd_vector.qza
    :saveas: faith_pd_vector.qza
 
 To view this artifact as metadata, simply pass it in to any method or visualizer that expects to see metadata (e.g. ``metadata tabulate`` or ``emperor plot``):
@@ -94,7 +94,7 @@ The resulting metadata after the merge will contain the intersection of the iden
 Metadata merging is supported anywhere that metadata is accepted in QIIME 2. For example, it might be interesting to color an Emperor plot based on the study metadata, or the sample alpha diversities. This can be accomplished by providing both the sample metadata mapping file *and* the ``SampleData[AlphaDiversity]`` artifact:
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/metadata/unweighted_unifrac_pcoa_results.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/metadata/unweighted_unifrac_pcoa_results.qza
    :saveas: unweighted_unifrac_pcoa_results.qza
 
 .. command-block::
@@ -115,11 +115,11 @@ Metadata in QIIME 2 can be applied to sample or features --- so far we have only
 To get started with feature metadata, first download the example files:
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/metadata/rep-seqs.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/metadata/rep-seqs.qza
    :saveas: rep-seqs.qza
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/metadata/taxonomy.qza
+   :url: https://data.qiime2.org/2017.8/tutorials/metadata/taxonomy.qza
    :saveas: taxonomy.qza
 
 We have downloaded a ``FeatureData[Sequence]`` file (``rep-seqs.qza``) and a ``FeatureData[Taxonomy]`` file (``taxonomy.qza``). We can merge (and ``tabulate``) these files to associate the representative sequences with their taxonomic annotations:
@@ -143,5 +143,5 @@ Finally, there are export options available in the visualizations produced from 
 .. LINKS:
 .. _Keemei: http://keemei.qiime.org/
 .. _`That work in QIIME 1`: http://qiime.org/documentation/file_formats.html#metadata-mapping-files
-.. _`evenness vector`: https://docs.qiime2.org/2017.7/data/tutorials/moving-pictures/core-metrics-results/evenness_vector.qza
-.. _`feature table artifact`: https://docs.qiime2.org/2017.7/data/tutorials/moving-pictures/table.qza
+.. _`evenness vector`: https://docs.qiime2.org/2017.8/data/tutorials/moving-pictures/core-metrics-results/evenness_vector.qza
+.. _`feature table artifact`: https://docs.qiime2.org/2017.8/data/tutorials/moving-pictures/table.qza

--- a/source/tutorials/moving-pictures.rst
+++ b/source/tutorials/moving-pictures.rst
@@ -22,7 +22,7 @@ Sample metadata
 Before starting the analysis, explore the sample metadata to familiarize yourself with the samples used in this study. The `sample metadata`_ is available as a Google Sheet. You can download this file as tab-separated text by selecting ``File`` > ``Download as`` > ``Tab-separated values``. Alternatively, the following command will download the sample metadata as tab-separated text and save it in the file ``sample-metadata.tsv``. This ``sample-metadata.tsv`` file is used throughout the rest of the tutorial.
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/moving-pictures/sample_metadata.tsv
+   :url: https://data.qiime2.org/2017.8/tutorials/moving-pictures/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 .. tip:: `Keemei`_ is a Google Sheets add-on for validating sample metadata. Validation of sample metadata is important before beginning any analysis. Try installing Keemei following the instructions on its website, and then validate the sample metadata spreadsheet linked above. The spreadsheet also includes a sheet with some invalid data to try out with Keemei.
@@ -39,11 +39,11 @@ Download the sequence reads that we'll use in this analysis. In this tutorial we
    mkdir emp-single-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
    :saveas: emp-single-end-sequences/barcodes.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
+   :url: https://data.qiime2.org/2017.8/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
    :saveas: emp-single-end-sequences/sequences.fastq.gz
 
 All data that is used as input to QIIME 2 is in form of QIIME 2 artifacts, which contain information about the type of data and the source of the data. So, the first thing we need to do is import these sequence data files into a QIIME 2 artifact.
@@ -336,7 +336,7 @@ In the next sections we'll begin to explore the taxonomic composition of the sam
 
 
 .. download::
-   :url: https://data.qiime2.org/2017.7/common/gg-13-8-99-515-806-nb-classifier.qza
+   :url: https://data.qiime2.org/2017.8/common/gg-13-8-99-515-806-nb-classifier.qza
    :saveas: gg-13-8-99-515-806-nb-classifier.qza
 
 .. command-block::
@@ -369,7 +369,7 @@ Next, we can view the taxonomic composition of our samples with interactive bar 
 .. note::
    The ``barplot`` visualizer used here provides a visual representation of the taxonomic composition of your samples, but does not provide statistics telling you which features differ in abundance across samples or groups of samples. Approaches for statistically quantifying taxonomic differences fall into the category of differential abundance testing. Differential abundance testing in microbiome analysis is an active area of research. There are two QIIME 2 plugins that can be used for this: `q2-gneiss`_ and `q2-composition`_. You can find a `draft tutorial for q2-gneiss here`_, and a `draft tutorial for q2-composition here`_.
 
-.. _sample metadata: https://data.qiime2.org/2017.7/tutorials/moving-pictures/sample_metadata
+.. _sample metadata: https://data.qiime2.org/2017.8/tutorials/moving-pictures/sample_metadata
 .. _Keemei: http://keemei.qiime.org
 .. _DADA2: https://www.ncbi.nlm.nih.gov/pubmed/27214047
 .. _Illumina Overview Tutorial: http://nbviewer.jupyter.org/github/biocore/qiime/blob/1.9.1/examples/ipynb/illumina_overview_tutorial.ipynb
@@ -384,7 +384,7 @@ Next, we can view the taxonomic composition of our samples with interactive bar 
 .. _Deblur: http://msystems.asm.org/content/2/2/e00191-16
 .. _basic quality-score-based filtering: http://www.nature.com/nmeth/journal/v10/n1/abs/nmeth.2276.html
 .. _Bokulich et al. (2013): http://www.nature.com/nmeth/journal/v10/n1/abs/nmeth.2276.html
-.. _q2-gneiss: https://docs.qiime2.org/2017.7/plugins/available/gneiss/
-.. _q2-composition: https://docs.qiime2.org/2017.7/plugins/available/composition/
+.. _q2-gneiss: https://docs.qiime2.org/2017.8/plugins/available/gneiss/
+.. _q2-composition: https://docs.qiime2.org/2017.8/plugins/available/composition/
 .. _draft tutorial for q2-gneiss here: https://forum.qiime2.org/t/balances-tutorial/913
 .. _draft tutorial for q2-composition here: https://forum.qiime2.org/t/ancom-tutorial-moving-pictures-of-the-human-microbiome-dataset/921


### PR DESCRIPTION
Updated:

- references to `2017.7` -> `2017.8`
- removed forum data links in favor of data.qiime2.org links
- updated scikit-learn version `0.18.2` -> `0.19.0`
- verified even sampling depth in Moving Pictures tutorial matches what is in
  the text
- added `q2-sample-classifier` and `q2-longitudinal` to Core distribution list