### PR TITLE
ENH: more citations in docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Documentation building requirements.
 Sphinx==1.4.6
 Jinja2
+sphinxcontrib-bibtex

--- a/source/conf.py
+++ b/source/conf.py
@@ -53,7 +53,8 @@ extensions = [
     'sphinx_extensions.qiime1',
     'sphinx_extensions.command_block',
     'sphinx_extensions.plugin_directory',
-    'sphinx_extensions.external_links'
+    'sphinx_extensions.external_links',
+    'sphinxcontrib.bibtex'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/sphinx_extensions/plugin_directory/templates/action.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/action.rst
@@ -1,6 +1,28 @@
 {{ title }}
 {{ '=' * title|length }}
 
+{% if has_citations %}
+.. raw:: html
+
+   <table class="table action-info">
+     <tbody>
+       <tr>
+         <th scope="row"><p></p>Citations</th>
+         <td>
+
+.. bibliography:: {{ bib_id }}.bib
+   :all:
+   :keyprefix: {{ bib_id }}:
+   :labelprefix: {{ bib_id}}:
+
+.. raw:: html
+
+         </td>
+       </tr>
+     </tbody>
+   </table>
+{% endif %}
+
 .. raw:: html
 
    <div class="tabbed">

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -27,14 +27,24 @@
            {% for line in plugin.user_support_text.splitlines() %}
            {{ line|urlize }}<br/>
            {% endfor %}
+
+{% if plugin.citations %}
+.. raw:: html
+
          </td>
        </tr>
        <tr>
-         <th scope="row">Citation</th>
+         <th scope="row"><p></p>Citations</th>
          <td>
-           {% for line in plugin.citation_text.splitlines() %}
-           {{ line|urlize }}<br/>
-           {% endfor %}
+
+.. bibliography:: citations.bib
+   :all:
+   :keyprefix: {{ plugin.name }}:
+   :labelprefix: {{ plugin.name }}:
+{% endif %}
+
+.. raw:: html
+
          </td>
        </tr>
      </tbody>

--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -144,3 +144,16 @@ form.search input[name=q]{
   }
 
 }
+
+/* Fix up sphinxcontrib-bibtex html */
+table.citation {
+  border-left: none;
+}
+
+table.citation td {
+  padding: 0px 0px 5px 0px;
+}
+
+table.citation td.label {
+  display: none;
+}


### PR DESCRIPTION
# Plugin
![image](https://user-images.githubusercontent.com/3976804/38894190-897c0082-425a-11e8-964d-ea8e8f500ab8.png)


# Action
![image](https://user-images.githubusercontent.com/3976804/38894230-9cb1150c-425a-11e8-80ae-15ed09ddb498.png)
**(copied the registration, in practice plot wouldn't really have its own citations)**
