### PR TITLE
BUG: added import and invocation to action and plugin pages

### DIFF
--- a/source/sphinx_extensions/plugin_directory/extension.py
+++ b/source/sphinx_extensions/plugin_directory/extension.py
@@ -57,6 +57,7 @@ def generate_rst(app):
             write_bibtex(plugin.citations, index_bib)
 
         for action in plugin.actions.values():
+            action_api_name = action.id
             action_cli_name = action.id.replace('_', '-')
             action_path = os.path.join(plugin_dir, '%s.rst' % action_cli_name)
 
@@ -84,8 +85,12 @@ def generate_rst(app):
                 template = env.get_template('action.rst')
                 rendered = template.render(title=title, cli_help=cli_help,
                                            api_help=api_help, bib_id=bib_id,
-                                           has_citations=bool(action.citations)
-                                           )
+                                           has_citations=bool(
+                                            action.citations),
+                                           plugin_cli_name=plugin_cli_name,
+                                           action_cli_name=action_cli_name,
+                                           plugin_api_name=plugin.name,
+                                           action_api_name=action_api_name)
                 fh.write(rendered)
 
 

--- a/source/sphinx_extensions/plugin_directory/extension.py
+++ b/source/sphinx_extensions/plugin_directory/extension.py
@@ -88,8 +88,6 @@ def generate_rst(app):
                                            api_help=api_help, bib_id=bib_id,
                                            has_citations=bool(
                                             action.citations),
-                                           plugin_cli_name=plugin_cli_name,
-                                           action_cli_name=action_cli_name,
                                            import_path=import_path,
                                            action_api_name=action_api_name)
                 fh.write(rendered)

--- a/source/sphinx_extensions/plugin_directory/extension.py
+++ b/source/sphinx_extensions/plugin_directory/extension.py
@@ -57,7 +57,6 @@ def generate_rst(app):
             write_bibtex(plugin.citations, index_bib)
 
         for action in plugin.actions.values():
-            action_api_name = action.id
             action_cli_name = action.id.replace('_', '-')
             action_path = os.path.join(plugin_dir, '%s.rst' % action_cli_name)
 
@@ -90,7 +89,7 @@ def generate_rst(app):
                                            plugin_cli_name=plugin_cli_name,
                                            action_cli_name=action_cli_name,
                                            plugin_api_name=plugin.name,
-                                           action_api_name=action_api_name)
+                                           action_api_name=action.id)
                 fh.write(rendered)
 
 

--- a/source/sphinx_extensions/plugin_directory/extension.py
+++ b/source/sphinx_extensions/plugin_directory/extension.py
@@ -57,6 +57,8 @@ def generate_rst(app):
             write_bibtex(plugin.citations, index_bib)
 
         for action in plugin.actions.values():
+            import_path, action_api_name = action.get_import_path().rsplit(
+                '.', 1)
             action_cli_name = action.id.replace('_', '-')
             action_path = os.path.join(plugin_dir, '%s.rst' % action_cli_name)
 
@@ -88,8 +90,8 @@ def generate_rst(app):
                                             action.citations),
                                            plugin_cli_name=plugin_cli_name,
                                            action_cli_name=action_cli_name,
-                                           plugin_api_name=plugin.name,
-                                           action_api_name=action.id)
+                                           import_path=import_path,
+                                           action_api_name=action_api_name)
                 fh.write(rendered)
 
 

--- a/source/sphinx_extensions/plugin_directory/templates/action.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/action.rst
@@ -40,7 +40,7 @@
 
 .. command-block::
 
-       from qiime2.plugins.{{plugin_api_name}}.actions import {{action_api_name}} as {{action_api_name}}
+       from {{import_path}} import {{action_api_name}}
 
 .. raw:: html
 

--- a/source/sphinx_extensions/plugin_directory/templates/action.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/action.rst
@@ -32,11 +32,15 @@
      </ul>
      <div class="tab-content">
        <div id="cli" class="tab-pane fade in active">
-         <pre>
-           {{- cli_help -}}
-         </pre>
+         <h4>Invocation:</h4>
+         <pre>qiime {{plugin_cli_name}} {{action_cli_name}} [OPTIONS]</pre>
+         <h4>Docstring:</h4>
+         <pre>{{- cli_help -}}</pre>
        </div>
        <div id="api" class="tab-pane fade">
+       <h4>Import:</h4>
+       <pre>from qiime2.plugins.{{- plugin_api_name -}}.actions import {{action_api_name}} as {{action_api_name}}</pre>
+       <h4>Docstring:</h4>
          <pre>
            {{- api_help -}}
          </pre>

--- a/source/sphinx_extensions/plugin_directory/templates/action.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/action.rst
@@ -32,14 +32,18 @@
      </ul>
      <div class="tab-content">
        <div id="cli" class="tab-pane fade in active">
-         <h4>Invocation:</h4>
-         <pre>qiime {{plugin_cli_name}} {{action_cli_name}} [OPTIONS]</pre>
          <h4>Docstring:</h4>
          <pre>{{- cli_help -}}</pre>
        </div>
        <div id="api" class="tab-pane fade">
        <h4>Import:</h4>
-       <pre>from qiime2.plugins.{{- plugin_api_name -}}.actions import {{action_api_name}} as {{action_api_name}}</pre>
+
+.. command-block::
+
+       from qiime2.plugins.{{plugin_api_name}}.actions import {{action_api_name}} as {{action_api_name}}
+
+.. raw:: html
+
        <h4>Docstring:</h4>
          <pre>
            {{- api_help -}}

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -27,6 +27,14 @@
            {% for line in plugin.user_support_text.splitlines() %}
            {{ line|urlize }}<br/>
            {% endfor %}
+       <tr>
+         <th scope="row">q2cli Invocation</th>
+         <td><pre>qiime {{ title }}</pre></td>
+       </tr>
+       <tr>
+         <th scope="row">Artifact API Import</th>
+         <td><pre> from qiime2.plugins import {{ title }}</pre></td>
+       </tr>
 
 {% if plugin.citations %}
 .. raw:: html

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -29,11 +29,27 @@
            {% endfor %}
        <tr>
          <th scope="row">q2cli Invocation</th>
-         <td><pre>qiime {{ title }}</pre></td>
+         <td>
+
+.. command-block::
+
+             qiime {{ title }}
+
+.. raw:: html
+
+         </td>
        </tr>
        <tr>
          <th scope="row">Artifact API Import</th>
-         <td><pre> from qiime2.plugins import {{ title }}</pre></td>
+         <td>
+
+.. command-block::
+
+             from qiime2.plugins import {{ title }}
+
+.. raw:: html
+
+         </td>
        </tr>
 
 {% if plugin.citations %}

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -45,7 +45,7 @@
 
 .. command-block::
 
-             from qiime2.plugins import {{ title }}
+             from qiime2.plugins import {{ title.replace('-', '_') }}
 
 .. raw:: html
 


### PR DESCRIPTION
fixes #307

Two aesthetic questions for discussion:

- [x] Copy to clipboard:
It is possible to add copy-to-clipboard buttons to both plugin- and action-page pre tags. I opted not to do so, because they felt cluttered, and I'm not convinced that copy-buttons bring much value in this context. 

**Compare:** 

![cropnocopy](https://user-images.githubusercontent.com/39198770/42340857-0bd885cc-8046-11e8-8ba6-93abc86df0e0.png)

![cropcopybuttons](https://user-images.githubusercontent.com/39198770/42340778-c9e8aad4-8045-11e8-9fdb-1c974171fb13.png)



- [x] Duplication of CLI Docstring Usage line:
On Action pages, I wanted parity in the look of the CLI and API tabs, so I added an "Invocation" block to the CLI tab to mirror the "Import" block in the API tab. The new "Invocation" block duplicates the usage text in the docstring, which looks a bit sloppy to me. 

We can: 
- Merge as is, retaining the content duplication (result: screencaps below, pro: quick/easy, con: duplication)
- Remove the "Invocation" block from the CLI tab (pro: quick/easy, con: loss of parity)
- Remove the "Usage" line from the CLI docstring that is shown in these docs, with no change to the docstring shown in the CLI itself. (pro: deduplicates, preserves parity, con: additional effort/code)

API: 
![cropactionnocopy](https://user-images.githubusercontent.com/39198770/42339525-101eb132-8042-11e8-8a9b-8c8d09078fb7.png)

CLI: 
![crop cli usage duplicated](https://user-images.githubusercontent.com/39198770/42339506-0271538c-8042-11e8-898a-a41c023c6a22.png)