### PR TITLE
ENH: Tuck the copy-to-clipboard away

### DIFF
--- a/source/sphinx_extensions/command_block/templates/download.html
+++ b/source/sphinx_extensions/command_block/templates/download.html
@@ -37,14 +37,19 @@
         <div class="clearfix"></div>
         <div class="highlight-shell">
           <div class="highlight">
-            <pre>wget -O "{{ node.saveas }}" "{{ node.url }}"</pre>
+            <pre>wget \
+  -O "{{ node.saveas }}" \
+  "{{ node.url }}"</pre>
           </div>
         </div>
       </div>
       <div role="tabpanel" class="tab-pane fade" id="curl-{{ node.id }}">
         <div class="highlight-shell">
           <div class="highlight">
-            <pre>curl -sL "{{ node.url }}" > "{{ node.saveas }}"</pre>
+            <pre>curl \
+  -sL \
+  "{{ node.url }}" > \
+  "{{ node.saveas }}"</pre>
           </div>
         </div>
       </div>

--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -157,3 +157,13 @@ table.citation td {
 table.citation td.label {
   display: none;
 }
+
+.highlight-shell {
+  position: relative;
+}
+
+.clipboard-btn {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+}


### PR DESCRIPTION
Stash the clipboard icon into the upper right corner of the command blocks:

![screen shot 2018-07-07 at 10 39 12 am](https://user-images.githubusercontent.com/274668/42413284-359b9a2e-81d2-11e8-8cb8-bc065d9ee0cd.png)

I reflowed the download blocks to prevent icon/text overlap.