### PR TITLE
BUG: fix python command-block to no-exec

### DIFF
--- a/source/_static/clipboard-driver.js
+++ b/source/_static/clipboard-driver.js
@@ -23,7 +23,7 @@ for (x = 0; x < highlightShellElements.length; x++)
 
   // Add the data-clipboard-text atribute to the clipboard button
   // Assign the pre elements text content to the data-clipboard-text attribute
-  clipboardButton.setAttribute("data-clipboard-text", preElements[0].textContent);
+  clipboardButton.setAttribute("data-clipboard-text", $.trim(preElements[0].textContent));
 
   // Get the command block root "div" element
   // insert the clipboardButton node as the first child of the command block root

--- a/source/sphinx_extensions/plugin_directory/templates/action.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/action.rst
@@ -39,8 +39,9 @@
        <h4>Import:</h4>
 
 .. command-block::
+   :no-exec:
 
-       from {{import_path}} import {{action_api_name}}
+   from {{import_path}} import {{action_api_name}}
 
 .. raw:: html
 

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -33,7 +33,7 @@
 
 .. command-block::
 
-             qiime {{ title }}
+   qiime {{ title }}
 
 .. raw:: html
 
@@ -44,8 +44,9 @@
          <td>
 
 .. command-block::
+   :no-exec:
 
-             from qiime2.plugins import {{ title.replace('-', '_') }}
+   from qiime2.plugins import {{ title.replace('-', '_') }}
 
 .. raw:: html
 


### PR DESCRIPTION
The command block directive is trying to run a shell command. Just add the `:no-exec:` directive argument to prevent that issue.

(Also fixed indentation)