### PR TITLE
BUG: One more no-exec on the rendered help text

### DIFF
--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -32,6 +32,7 @@
          <td>
 
 .. command-block::
+   :no-exec:
 
    qiime {{ title }}
 


### PR DESCRIPTION
Tested locally with `make html`, this builds without error (well, tested up to the tutorials, then terminated the build).