### PR TITLE
MAINT: move maturity-index tutorial

### DIFF
--- a/source/tutorials/longitudinal.rst
+++ b/source/tutorials/longitudinal.rst
@@ -253,7 +253,60 @@ Finally, we can compute principal coordinates and use Emperor to visualize simil
 
 So there it is. We can use PERMANOVA test or other distance-based statistical tests to determine whether groups exhibit different longitudinal microbial interdependence relationships, and PCoA/emperor to visualize the relationships among groups of subjects. **Don't forget the caveats mentioned above about using and interpreting NMIT**. Now be safe and have fun.
 
+"Maturity Index" prediction
+---------------------------
+
+.. note:: This analysis currently works best for comparing groups that are sampled fairly evenly across time (the column used for regression). Datasets that contain groups sampled sporadically at different times are not supported, and users should either filter out those samples or “bin” them with other groups prior to using this visualizer.
+.. note:: This analysis will only work on data sets with a large sample size, particularly in the "control" group, and with sufficient biological replication at each time point.
+
+This method calculates a "microbial maturity" index from a regression model trained on feature data to predict a given continuous metadata column ("state_column"), e.g., to predict a subject's age as a function of microbiota composition. This method is different from standard supervised regression because it quantifies the relative rate of change over time in two or more groups. The model is trained on a subset of control group samples, then predicts the column value for all samples. This visualization computes maturity index z-scores (MAZ) to compare relative "maturity" between each group, as described in `Sathish et al. 2014`_. This method was designed to predict between-group differences in intestinal microbiome development by age, so ``state_column`` should typically be a measure of time. Other types of continuous metadata gradients might be testable, as long as two or more different "treatment" groups are being compared *with a large number of biological replicates* in the "control" group and treatment groups are sampled at the same "states" (time or position on gradient) for comparison. However, we do not necessarily recommend *or offer technical support* for unusual approaches.
+
+
+First download a table to work with:
+
+.. download::
+   :url: https://data.qiime2.org/2018.8/tutorials/longitudinal/ecam_table_maturity.qza
+   :saveas: ecam-table.qza
+
+Here we will compare microbial maturity between vaginally born and cesarean-delivered infants as a function of age in the ECAM dataset.
+
+.. command-block::
+
+   qiime longitudinal maturity-index \
+     --i-table ecam-table.qza \
+     --m-metadata-file ecam-sample-metadata.tsv \
+     --p-state-column month \
+     --p-group-by delivery \
+     --p-individual-id-column studyid \
+     --p-control Vaginal \
+     --p-test-size 0.4 \
+     --output-dir maturity
+
+This pipeline produces several output files:
+
+1. ``accuracy_results.qzv`` contains a linear regression plot of predicted vs. expected values on all control test samples (as described above for regression models). This is a subset of "control" samples that were not used for model training (the fraction defined by the ``test-size`` parameter).
+
+2. ``lineplots.qzv`` contains an interactive volitility chart. This visualization can be useful for assessing how MAZ and other metrics change over time in each sample group (by default, the ``group_by`` column is used but other sample metadata may be selected for grouping samples). The default metric displayed on this chart is MAZ scores for the chosen ``state_column``. The "prediction" (predicted "state_column" values) and state_column "maturity" metrics are other metrics calculated by this plugin that can be interesting to explore. See `Sathish et al. 2014`_ for more details on the MAZ and maturity metrics.
+
+3. ``clustermap.qzv`` contains a heatmap showing the frequency of each important feature across time in each group. This plot is useful for visualizing how the frequency of important features changes over time in each group, demonstrating how different patterns of feature abundance (e.g., trajectories of development in the case of age or time-based models) may affect model predictions and MAZ scores. Important features shown along the x-axis; samples grouped and ordered by ``group_by`` and ``state_column`` are shown on the y-axis. See :doc:`heatmap <../plugins/available/feature-table/heatmap/>` for details on how features are clustered along the x-axis (default parameters are used).
+
+4. ``maz_scores.qza`` contains MAZ scores for each sample (excluding training samples). This is useful for downstream testing as described below.
+
+5. ``predictions.qza`` contains "state column" predictions for each sample (excluding training samples). These predictions are used to calculate the MAZ scores, and a subset (control test samples) are used to assess model accuracy. Nonetheless, the predictions are supplied in case they prove useful...
+
+6. ``feature_importance.qza`` contains importance scores for all features included in the final regression model. If the ``optimize-feature-selection`` parameter is used, this will only contain important features; if not, importance scores will be assigned to all features in the original feature table.
+
+7. ``sample_estimator.qza`` contains the trained ``SampleEstimator[Regressor]``. You probably will not want to re-use this estimator for predicting other samples (since it is trained on a subset of samples), but nevertheless it is supplied for the curious and intrepid.
+
+8. ``model_summary.qzv`` contains a summary of the model parameters used by the supervised learning estimator, as described above for the equivalently named outputs from the ``classify-samples`` pipeline.
+
+So what does this all show us? In the ECAM dataset that we are testing here, we see that MAZ scores are suppressed in Cesarean-delivered subjects in the second year of life, compared to vaginally born subjects (See ``lineplots.qzv``). Several important sequence variants exhibit reduced frequency during this time frame, suggesting involvement in delayed maturation of the Cesarean cohort (See ``clustermap.qzv``). (This tutorial example does not have a ``random-state`` set so local results may vary slightly)
+
+Note that none of the results presented so far actually confirm a statistical difference between groups. Want to take this analysis to the next level (with multivariate statistical testing)? Use the MAZ scores (or possibly ``predictions``) as input metrics (dependent variables) in linear mixed effects models (as described above).
+
+
 .. _ECAM study: https://doi.org/10.1126/scitranslmed.aad7121
 .. _statsmodels LME description page: http://www.statsmodels.org/dev/mixed_linear.html
 .. _Vega Editor: https://vega.github.io/vega/docs/
 .. _Zhang et al., 2017: https://doi.org/10.1002/gepi.22065
+.. _Sathish et al. 2014: https://doi.org/10.1038/nature13421

--- a/source/tutorials/sample-classifier.rst
+++ b/source/tutorials/sample-classifier.rst
@@ -228,51 +228,6 @@ There are NCV methods in ``q2-sample-classifier`` for both classification and re
 So the NCV methods output feature importance scores and sample predictions, but not trained estimators (as is done for the ``classify-samples`` and ``regress-samples`` pipelines above). This is because (1) *k* models are actually used for prediction, where *k* = the number of CV folds used in the outer loop, so returning and re-using the estimators would get very messy; and (2) users interested in NCV are *most likely* not interested in re-using the models for predicting new samples.
 
 
-"Maturity Index" prediction
----------------------------
-
-.. note:: This analysis currently works best for comparing groups that are sampled fairly evenly across time (the column used for regression). Datasets that contain groups sampled sporadically at different times are not supported, and users should either filter out those samples or “bin” them with other groups prior to using this visualizer.
-.. note:: This analysis will only work on data sets with a large sample size, particularly in the "control" group, and with sufficient biological replication at each time point.
-
-This method calculates a "microbial maturity" index from a regression model trained on feature data to predict a given continuous metadata column ("state_column"), e.g., to predict a subject's age as a function of microbiota composition. This method is different from standard supervised regression because it quantifies the relative rate of change over time in two or more groups. The model is trained on a subset of control group samples, then predicts the column value for all samples. This visualization computes maturity index z-scores (MAZ) to compare relative "maturity" between each group, as described in `Sathish et al. 2014`_. This method was designed to predict between-group differences in intestinal microbiome development by age, so ``state_column`` should typically be a measure of time. Other types of continuous metadata gradients might be testable, as long as two or more different "treatment" groups are being compared *with a large number of biological replicates* in the "control" group and treatment groups are sampled at the same "states" (time or position on gradient) for comparison. However, we do not necessarily recommend *or offer technical support* for unusual approaches.
-
-Here we will compare microbial maturity between vaginally born and cesarean-delivered infants as a function of age in the ECAM dataset.
-
-.. command-block::
-
-   qiime sample-classifier maturity-index \
-     --i-table ecam-table.qza \
-     --m-metadata-file ecam-metadata.tsv \
-     --p-state-column month \
-     --p-group-by delivery \
-     --p-individual-id-column studyid \
-     --p-control Vaginal \
-     --p-test-size 0.4 \
-     --output-dir maturity
-
-This pipeline produces several output files:
-
-1. ``accuracy_results.qzv`` contains a linear regression plot of predicted vs. expected values on all control test samples (as described above for regression models). This is a subset of "control" samples that were not used for model training (the fraction defined by the ``test-size`` parameter).
-
-2. ``lineplots.qzv`` contains an interactive volitility chart as described in the :doc:`longitudinal tutorial <longitudinal>`. This visualization can be useful for assessing how MAZ and other metrics change over time in each sample group (by default, the ``group_by`` column is used but other sample metadata may be selected for grouping samples). The default metric displayed on this chart is MAZ scores for the chosen ``state_column``. The "prediction" (predicted "state_column" values) and state_column "maturity" metrics are other metrics calculated by this plugin that can be interesting to explore. See `Sathish et al. 2014`_ for more details on the MAZ and maturity metrics.
-
-3. ``clustermap.qzv`` contains a heatmap showing the frequency of each important feature across time in each group. This plot is useful for visualizing how the frequency of important features changes over time in each group, demonstrating how different patterns of feature abundance (e.g., trajectories of development in the case of age or time-based models) may affect model predictions and MAZ scores. Important features shown along the x-axis; samples grouped and ordered by ``group_by`` and ``state_column`` are shown on the y-axis. See :doc:`heatmap <../plugins/available/feature-table/heatmap/>` for details on how features are clustered along the x-axis (default parameters are used).
-
-4. ``maz_scores.qza`` contains MAZ scores for each sample (excluding training samples). This is useful for downstream testing as described below.
-
-5. ``predictions.qza`` contains "state column" predictions for each sample (excluding training samples). These predictions are used to calculate the MAZ scores, and a subset (control test samples) are used to assess model accuracy. Nonetheless, the predictions are supplied in case they prove useful...
-
-6. ``feature_importance.qza`` contains importance scores for all features included in the final regression model. If the ``optimize-feature-selection`` parameter is used, this will only contain important features; if not, importance scores will be assigned to all features in the original feature table.
-
-7. ``sample_estimator.qza`` contains the trained ``SampleEstimator[Regressor]``. You probably will not want to re-use this estimator for predicting other samples (since it is trained on a subset of samples), but nevertheless it is supplied for the curious and intrepid.
-
-8. ``model_summary.qzv`` contains a summary of the model parameters used by the supervised learning estimator, as described above for the equivalently named outputs from the ``classify-samples`` pipeline.
-
-So what does this all show us? In the ECAM dataset that we are testing here, we see that MAZ scores are suppressed in Cesarean-delivered subjects in the second year of life, compared to vaginally born subjects (See ``lineplots.qzv``). Several important sequence variants exhibit reduced frequency during this time frame, suggesting involvement in delayed maturation of the Cesarean cohort (See ``clustermap.qzv``). (This tutorial example does not have a ``random-state`` set so local results may vary slightly)
-
-Note that none of the results presented so far actually confirm a statistical difference between groups. Want to take this analysis to the next level (with multivariate statistical testing)? Use the MAZ scores (or possibly ``predictions``) as input metrics (dependent variables) in :doc:`linear mixed effects models <longitudinal>`.
-
-
 Best practices: things you should not do with q2-sample-classifier
 ------------------------------------------------------------------
 
@@ -297,6 +252,5 @@ As this tutorial has demonstrated, q2-sample-classifier can be extremely powerfu
 .. _scikit-learn documentation: http://scikit-learn.org/stable/supervised_learning.html
 .. _estimator selection flowchart: http://scikit-learn.org/stable/tutorial/machine_learning_map/index.html
 .. _recursive feature elimination: http://scikit-learn.org/stable/modules/feature_selection.html#recursive-feature-elimination
-.. _Sathish et al. 2014: https://doi.org/10.1038/nature13421
 .. _cross-validation: https://en.wikipedia.org/wiki/Cross-validation_(statistics)
 .. _mislabeled samples: https://doi.org/10.1038/ismej.2010.148


### PR DESCRIPTION
Brief summary of the Pull Request, including any issues it may fix using the GitHub closing syntax:

Just swaps the section to the longitudinal tutorial.

A download link was added for the ecam table, inter-tutorial links removed, since the content referenced is on the same page, and the metadata input file was renamed to match the rest of the tutorial.

I'm pretty sure this should work...