### PR TITLE
HACK: drop ilr-phylogenetic from gneiss tutorial

### DIFF
--- a/source/tutorials/gneiss.rst
+++ b/source/tutorials/gneiss.rst
@@ -114,15 +114,6 @@ Now that we have a tree that defines our partitions, we can perform the isometri
      --i-tree hierarchy.qza \
      --o-balances balances.qza
 
-
-Alternatively, as mentioned earlier we can use a phylogenetic tree to create our balances:
-.. command-block::
-
-   qiime gneiss ilr-phylogenetic \
-     --i-table table.qza \
-     --i-tree rooted-tree.qza \
-     --o-balances phylogenetic-balances.qza
-
 Now that we have the log ratios of each node of our tree, we can run linear regression on the balances. The linear regression that we will be running is called a `multivariate response linear regression`_, which boils down to performing a linear regression on each balance separately.
 
 We can use this to attempt to associate microbial abundances with environmental variables. Running these models has multiple advantages over standard univariate regression, as it avoids many of the issues associated with overfitting, and can allow us to gain perspective about community-wide perturbations based on environmental parameters.


### PR DESCRIPTION
Command block was never executed (missing preceding newline) so we didn't realize that rooted-tree.qza doesn't exist, it's easier to just drop for now.
