### PR TITLE
Copypasta error on beta-group-significance

### DIFF
--- a/source/tutorials/fmt-cdiff.rst
+++ b/source/tutorials/fmt-cdiff.rst
@@ -349,7 +349,7 @@ Next we'll analyze sample composition in the context of categorical metadata usi
    qiime diversity beta-group-significance \
      --i-distance-matrix core-metrics-results/unweighted_unifrac_distance_matrix.qza \
      --m-metadata-file sample_metadata.tsv \
-     --m-metadata-column disease_state \
+     --m-metadata-column animations_subject \
      --p-pairwise \
      --o-visualization core-metrics-results/unweighted-unifrac-animations-subject-group-significance.qzv
 


### PR DESCRIPTION
Beta group significance results from the alpha/beta core diversity section are identical but the output filenames suggest otherwise. On closer inspection, it looks as though the filename was updated in one of the commands but the specific metadata category used did not get updated. 