### PR TITLE
set random seeds in q2-sample-classifier and q2-longitudinal tutorials

### DIFF
--- a/source/tutorials/longitudinal.rst
+++ b/source/tutorials/longitudinal.rst
@@ -339,7 +339,7 @@ This pipeline produces several output files:
 
 8. ``model_summary.qzv`` contains a summary of the model parameters used by the supervised learning estimator, as described in the :doc:`sample classifier tutorial <sample-classifier>` for the equivalently named outputs from the ``classify-samples`` pipeline.
 
-So what does this all show us? In the ECAM dataset that we are testing here, we see that MAZ scores are suppressed in Cesarean-delivered subjects in the second year of life, compared to vaginally born subjects (See ``volatility-plots.qzv``). Several important sequence variants exhibit reduced frequency during this time frame, suggesting involvement in delayed maturation of the Cesarean cohort (See ``clustermap.qzv``). (This tutorial example does not have a ``random-state`` set so local results may vary slightly)
+So what does this all show us? In the ECAM dataset that we are testing here, we see that MAZ scores are suppressed in Cesarean-delivered subjects in the second year of life, compared to vaginally born subjects (See ``volatility-plots.qzv``). Several important sequence variants exhibit reduced frequency during this time frame, suggesting involvement in delayed maturation of the Cesarean cohort (See ``clustermap.qzv``).
 
 Note that none of the results presented so far actually confirm a statistical difference between groups. Want to take this analysis to the next level (with multivariate statistical testing)? Use the MAZ scores (or possibly ``predictions``) as input metrics (dependent variables) in linear mixed effects models (as described above).
 

--- a/source/tutorials/longitudinal.rst
+++ b/source/tutorials/longitudinal.rst
@@ -275,7 +275,7 @@ Let's test this out on the ECAM dataset. First download a table to work with:
      --p-state-column month \
      --p-individual-id-column studyid \
      --p-n-estimators 10 \
-     --p-random-state 123 \
+     --p-random-state 17 \
      --output-dir ecam-feat-volatility
 
 All of the parameters used in this pipeline are described for other ``q2-longitudinal`` actions or in the :doc:`sample classifier tutorial <sample-classifier>`, so will not be discussed here. This pipeline produces multiple outputs:

--- a/source/tutorials/sample-classifier.rst
+++ b/source/tutorials/sample-classifier.rst
@@ -57,6 +57,7 @@ Next, we will train and test a classifier that predicts which body site a sample
      --p-parameter-tuning \
      --p-estimator RandomForestClassifier \
      --p-n-estimators 20 \
+     --p-random-state 123 \
      --output-dir moving-pictures-classifier
 
 
@@ -161,6 +162,7 @@ Next, we will train a regressor to predict an infant's age based on its microbio
      --m-metadata-column month \
      --p-estimator RandomForestRegressor \
      --p-n-estimators 20 \
+     --p-random-state 123 \
      --output-dir ecam-regressor
 
 
@@ -193,6 +195,7 @@ There are NCV methods in ``q2-sample-classifier`` for both classification and re
      --m-metadata-column BodySite \
      --p-estimator RandomForestClassifier \
      --p-n-estimators 20 \
+     --p-random-state 123 \
      --o-predictions BodySite-predictions-ncv.qza \
      --o-feature-importance BodySite-importance-ncv.qza
 
@@ -214,6 +217,7 @@ There are NCV methods in ``q2-sample-classifier`` for both classification and re
      --m-metadata-column month \
      --p-estimator RandomForestRegressor \
      --p-n-estimators 20 \
+     --p-random-state 123 \
      --o-predictions ecam-predictions-ncv.qza \
      --o-feature-importance ecam-importance-ncv.qza
 


### PR DESCRIPTION
now all commands have random seeds specified.

fixes #366 

Also set a different seed for q2-feature-volatility — the original command ran but was making an excessively large viz that would not display volatility plots on some machines.