### PR TITLE
MAINT: Updates link to Conda install page, fixes 404

### DIFF
--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -86,7 +86,7 @@ Next steps
 
 Now that you have the Core distribution installed, check out the :doc:`q2cli docs <../interfaces/q2cli>` to get familiar with the QIIME 2 command-line interface (it is used extensively in the :doc:`tutorials <../tutorials/index>`). After that, try out the :doc:`QIIME 2 tutorials <../tutorials/index>` for examples of using QIIME 2 to analyze microbiome datasets. You might also try installing other QIIME 2 :doc:`interfaces <../interfaces/index>`.
 
-.. _`Miniconda`: https://conda.io/miniconda.html
+.. _`Miniconda`: https://conda.io/projects/continuumio-conda/en/latest/user-guide/install/index.html
 
 
 How do I update to the newest version of QIIME 2?


### PR DESCRIPTION
Conda appears to have removed <https://conda.io/miniconda.html>

![image](https://user-images.githubusercontent.com/39198770/51556994-e9248f80-1e38-11e9-9634-753df22e8154.png)