### PR TITLE
MAINT: Sphinx 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 # Documentation building requirements.
-# TODO: unpin this
-Sphinx==1.4.6
+Sphinx
 Jinja2
-# TODO: unpin this
-sphinxcontrib-bibtex==0.4.0
+sphinxcontrib-bibtex

--- a/source/sphinx_extensions/command_block/extension.py
+++ b/source/sphinx_extensions/command_block/extension.py
@@ -21,12 +21,14 @@ import docutils.parsers.rst.directives
 import docutils.statemachine
 import jinja2
 import sphinx
+from sphinx.util import logging
 
 import qiime2
 
 
 loader = jinja2.PackageLoader('sphinx_extensions.command_block', 'templates')
 jinja_env = jinja2.Environment(loader=loader)
+logger = logging.getLogger(__name__)
 
 
 class download_node(docutils.nodes.Element):
@@ -124,14 +126,13 @@ class CommandBlockDirective(docutils.parsers.rst.Directive):
         return node
 
     def _execute_commands(self, commands, working_dir):
-        app = self._get_env().app
         for command in commands:
             command = command.strip()
             if not command:
                 continue
 
             try:
-                app.info("Running command: %s" % command)
+                logger.info("Running command: %s" % command)
                 comp_proc = subprocess.run(command,
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.PIPE,

--- a/source/sphinx_extensions/plugin_directory/extension.py
+++ b/source/sphinx_extensions/plugin_directory/extension.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 def generate_rst(app):
-    logger.info("Generating QIIME 2 plugin directory... (this may take awhile)")
+    logger.info(
+        "Generating QIIME 2 plugin directory... (this may take a while)")
 
     # Refresh the CLI cache just in case it is out of date with what's
     # installed (this should only affect packages while they are installed in
@@ -76,7 +77,7 @@ def generate_rst(app):
                 directive_indent = ' ' * 3
 
                 logger.info("Generating help text for `%s %s`..." %
-                         (plugin_cli_name, action_cli_name))
+                            (plugin_cli_name, action_cli_name))
                 command = ['qiime', plugin_cli_name, action_cli_name, '--help']
                 proc = subprocess.run(command, check=True,
                                       stdout=subprocess.PIPE,

--- a/source/sphinx_extensions/plugin_directory/extension.py
+++ b/source/sphinx_extensions/plugin_directory/extension.py
@@ -15,9 +15,12 @@ import textwrap
 import jinja2
 import qiime2.sdk
 
+from sphinx.util import logging
+logger = logging.getLogger(__name__)
+
 
 def generate_rst(app):
-    app.info("Generating QIIME 2 plugin directory... (this may take awhile)")
+    logger.info("Generating QIIME 2 plugin directory... (this may take awhile)")
 
     # Refresh the CLI cache just in case it is out of date with what's
     # installed (this should only affect packages while they are installed in
@@ -72,7 +75,7 @@ def generate_rst(app):
                 title = '%s: %s' % (action_cli_name, action.name)
                 directive_indent = ' ' * 3
 
-                app.info("Generating help text for `%s %s`..." %
+                logger.info("Generating help text for `%s %s`..." %
                          (plugin_cli_name, action_cli_name))
                 command = ['qiime', plugin_cli_name, action_cli_name, '--help']
                 proc = subprocess.run(command, check=True,

--- a/source/sphinx_extensions/plugin_directory/templates/action.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/action.rst
@@ -11,6 +11,7 @@
          <td>
 
 .. bibliography:: {{ bib_id }}.bib
+   :list: bullet
    :all:
    :keyprefix: {{ bib_id }}:
    :labelprefix: {{ bib_id}}:

--- a/source/sphinx_extensions/plugin_directory/templates/plugin.rst
+++ b/source/sphinx_extensions/plugin_directory/templates/plugin.rst
@@ -64,6 +64,7 @@
          <td>
 
 .. bibliography:: citations.bib
+   :list: bullet
    :all:
    :keyprefix: {{ plugin.name }}:
    :labelprefix: {{ plugin.name }}:

--- a/source/sphinx_extensions/qiime1.py
+++ b/source/sphinx_extensions/qiime1.py
@@ -7,42 +7,33 @@
 # ----------------------------------------------------------------------------
 
 from docutils import nodes
-from docutils.parsers.rst import Directive
-from sphinx.util.compat import make_admonition
+from sphinx.util.docutils import SphinxDirective
 
 
-class qiime1users(nodes.Admonition, nodes.Element):
+class QIIME1UsersAdmonition(nodes.Admonition, nodes.Element):
     pass
 
 
-def visit_qiime1users_node(self, node):
-    self.visit_admonition(node)
-
-
-def depart_qiime1users_node(self, node):
-    self.depart_admonition(node)
-
-
-class QIIME1UsersDirective(Directive):
+class QIIME1UsersDirective(SphinxDirective):
     has_content = True
 
     def run(self):
-        env = self.state.document.settings.env
+        target_id = 'qiime1users-%d' % self.env.new_serialno('qiime1users')
+        target_node = nodes.target('', '', ids=[target_id])
 
-        targetid = 'qiime1users-%d' % env.new_serialno('qiime1users')
-        targetnode = nodes.target('', '', ids=[targetid])
+        qiime1user_node = QIIME1UsersAdmonition(self.content)
+        qiime1user_node += nodes.title(text='QIIME 1 Users')
+        qiime1user_node['classes'] += ['qiime1']
+        self.state.nested_parse(self.content, self.content_offset,
+                                qiime1user_node)
 
-        self.options['class'] = ['qiime1']
-        ad = make_admonition(qiime1users, self.name, ['QIIME 1 Users'],
-                             self.options, self.content, self.lineno,
-                             self.content_offset, self.block_text, self.state,
-                             self.state_machine)
-        return [targetnode] + ad
+        return [target_node, qiime1user_node]
 
 
 def setup(app):
-    app.add_node(qiime1users,
-                 html=(visit_qiime1users_node, depart_qiime1users_node))
+    app.add_node(QIIME1UsersAdmonition,
+                 html=(lambda s, n: s.visit_admonition(n),
+                       lambda s, n: s.depart_admonition(n)))
     app.add_directive('qiime1-users', QIIME1UsersDirective)
 
-    return {'version': '0.0.1'}
+    return {'version': '0.0.2'}

--- a/source/sphinx_extensions/question.py
+++ b/source/sphinx_extensions/question.py
@@ -7,40 +7,33 @@
 # ----------------------------------------------------------------------------
 
 from docutils import nodes
-from docutils.parsers.rst import Directive
-from sphinx.util.compat import make_admonition
+from sphinx.util.docutils import SphinxDirective
 
 
-class question(nodes.Admonition, nodes.Element):
+class QuestionAdmonition(nodes.Admonition, nodes.Element):
     pass
 
 
-def visit_question_node(self, node):
-    self.visit_admonition(node)
-
-
-def depart_question_node(self, node):
-    self.depart_admonition(node)
-
-
-class QuestionDirective(Directive):
+class QuestionDirective(SphinxDirective):
     has_content = True
 
     def run(self):
-        env = self.state.document.settings.env
+        target_id = 'question-%d' % self.env.new_serialno('question')
+        target_node = nodes.target('', '', ids=[target_id])
 
-        targetid = 'question-%d' % env.new_serialno('question')
-        targetnode = nodes.target('', '', ids=[targetid])
+        question_node = QuestionAdmonition(self.content)
+        question_node += nodes.title(text='Question')
+        question_node['classes'] += ['question']
+        self.state.nested_parse(self.content, self.content_offset,
+                                question_node)
 
-        self.options['class'] = ['question']
-        ad = make_admonition(question, self.name, ['Question'], self.options,
-                             self.content, self.lineno, self.content_offset,
-                             self.block_text, self.state, self.state_machine)
-        return [targetnode] + ad
+        return [target_node, question_node]
 
 
 def setup(app):
-    app.add_node(question, html=(visit_question_node, depart_question_node))
+    app.add_node(QuestionAdmonition,
+                 html=(lambda s, n: s.visit_admonition(n),
+                       lambda s, n: s.depart_admonition(n)))
     app.add_directive('question', QuestionDirective)
 
-    return {'version': '0.0.1'}
+    return {'version': '0.0.2'}


### PR DESCRIPTION
Sphinx 2.0 recently landed --- this changeset updates the user docs to work with the latest (and greatest). Most of the changes have to do with our custom admonitions, and some deprecated APIs. Also, I had to update the bibtex render style to something other than the default, which is a set of paragraph elements. Paragraphs get cross-references in Sphinx --- this causes the build to fail because there are no corresponding citations in the docs anywhere. My solution was to change to a bullet list, since those elements don't get the cross-reference treatment!