### PR TITLE
DEP:Updates sk-learn data-resources to v0.21.2

### DIFF
--- a/source/data-resources.rst
+++ b/source/data-resources.rst
@@ -6,21 +6,21 @@ Taxonomy classifiers for use with q2-feature-classifier
 
 .. danger:: Pre-trained classifiers that can be used with ``q2-feature-classifier`` currently present a security risk. If using a pre-trained classifier such as the ones provided here, you should trust the person who trained the classifier and the person who provided you with the qza file. This security risk will be addressed in a future version of ``q2-feature-classifier``.
 
-.. warning:: These classifiers were trained using scikit-learn 0.20.2, and therefore can only be used with scikit-learn 0.20.2. If you are using a native installation of QIIME, before using these classifiers you should run the following to ensure that you are using the correct version of scikit-learn. If you are using a QIIME 2019.7 virtual machine, scikit-learn 0.20.2 will be installed and you do not need to run this command. The scikit-learn version restriction will be relaxed in a future version of ``q2-feature-classifier``.
+.. warning:: These classifiers were trained using scikit-learn 0.21.2, and therefore can only be used with scikit-learn 0.21.2. If you are using a native installation of QIIME, before using these classifiers you should run the following to ensure that you are using the correct version of scikit-learn. If you are using a QIIME 2019.7 virtual machine, scikit-learn 0.21.2 will be installed and you do not need to run this command. The scikit-learn version restriction will be relaxed in a future version of ``q2-feature-classifier``.
 
    .. command-block::
       :no-exec:
 
-      conda install --override-channels -c defaults scikit-learn=0.20.2
+      conda install --override-channels -c defaults scikit-learn=0.21.2
 
 .. note:: Taxonomic classifiers perform best when they are trained based on your specific sample preparation and sequencing parameters, including the primers that were used for amplification and the length of your sequence reads. Therefore in general you should follow the instructions in :doc:`Training feature classifiers with q2-feature-classifier <../tutorials/feature-classifier>` to train your own taxonomic classifiers (for example, from the marker gene reference databases below).
 
 Naive Bayes classifiers trained on:
 
-- `Silva 132 99% OTUs full-length sequences <https://data.qiime2.org/2019.7/common/silva-132-99-nb-classifier.qza>`_ (MD5: ``a4d0da77c39da87ee1affa06b61d1224``)
-- `Silva 132 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2019.7/common/silva-132-99-515-806-nb-classifier.qza>`_ (MD5: ``9f50514214ffb6fee9d2f87a47a51076``)
-- `Greengenes 13_8 99% OTUs full-length sequences <https://data.qiime2.org/2019.7/common/gg-13-8-99-nb-classifier.qza>`_ (MD5: ``581f97e4294cce93102b00ffaf8a1d9a``)
-- `Greengenes 13_8 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2019.7/common/gg-13-8-99-515-806-nb-classifier.qza>`_ (MD5: ``3afcc86150423263b3a7d983789ad0a3``)
+- `Silva 132 99% OTUs full-length sequences <https://data.qiime2.org/2019.7/common/silva-132-99-nb-classifier.qza>`_ (MD5: ``6a9aa92fc12f6e26d17df18b3e603417``)
+- `Silva 132 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2019.7/common/silva-132-99-515-806-nb-classifier.qza>`_ (MD5: ``a0925e86cda18829f84f03dab01ff589``)
+- `Greengenes 13_8 99% OTUs full-length sequences <https://data.qiime2.org/2019.7/common/gg-13-8-99-nb-classifier.qza>`_ (MD5: ``abb3da907ef432bcaf70b65027983b23``)
+- `Greengenes 13_8 99% OTUs from 515F/806R region of sequences <https://data.qiime2.org/2019.7/common/gg-13-8-99-515-806-nb-classifier.qza>`_ (MD5: ``21abd658436daf40f10c5a42ef9a8c66``)
 
 .. _`marker gene db`:
 


### PR DESCRIPTION
Rebuilt classifiers in latest version, because v21.2 fixes a bug introduced in v0.21, and present in v0.21.1.

Not pinning version number in `q2-feature-classifier` unless [`{{ pin_compatible('scikit-learn', exact=True) }}`](https://github.com/qiime2/q2-feature-classifier/commit/e920493139c04abcc92e0ad5c4ea18e0e7971d68) fails to work as expected.