### PR TITLE
MAINT: Change tutorials from q-score-joined to q-score

### DIFF
--- a/source/tutorials/qiime2-for-experienced-microbiome-researchers.rst
+++ b/source/tutorials/qiime2-for-experienced-microbiome-researchers.rst
@@ -235,7 +235,7 @@ Quality filtering
 **Relevant plugin**: :doc:`quality-filter <../plugins/available/quality-filter/index>`
 
 You can perform different types of quality filtering with the :doc:`quality filter <../plugins/available/quality-filter/index>` plugin.
-The `q-score` method is for single- or paired-end sequences (i.e. `SampleData[PairedEndSequencesWithQuality | SequencesWithQuality]`) while `q-score-joined` is for joined reads (i.e. `SampleData[JoinedSequencesWithQuality]` after merging).
+The `q-score` method is for single- or paired-end sequences as well as joined reads after merging (i.e. `SampleData[PairedEndSequencesWithQuality | SequencesWithQuality] | SampleData[JoinedSequencesWithQuality]`).
 The option descriptions for each method cover the different types of available quality filtering.
 
 Dereplicating sequences

--- a/source/tutorials/qiime2-for-experienced-microbiome-researchers.rst
+++ b/source/tutorials/qiime2-for-experienced-microbiome-researchers.rst
@@ -235,7 +235,7 @@ Quality filtering
 **Relevant plugin**: :doc:`quality-filter <../plugins/available/quality-filter/index>`
 
 You can perform different types of quality filtering with the :doc:`quality filter <../plugins/available/quality-filter/index>` plugin.
-The `q-score` method is for single- or paired-end sequences as well as joined reads after merging (i.e. `SampleData[PairedEndSequencesWithQuality | SequencesWithQuality] | SampleData[JoinedSequencesWithQuality]`).
+The `q-score` method is for single- or paired-end sequences as well as joined reads after merging (i.e. `SampleData[PairedEndSequencesWithQuality | SequencesWithQuality] | JoinedSequencesWithQuality]`).
 The option descriptions for each method cover the different types of available quality filtering.
 
 Dereplicating sequences

--- a/source/tutorials/read-joining.rst
+++ b/source/tutorials/read-joining.rst
@@ -118,7 +118,7 @@ If you are instead interested in experimenting with an analysis workflow that
 is more like QIIME 1 processing (for example, to compare your Deblur or DADA2
 result with a QIIME 1-like pipeline), you should next dereplicate and cluster
 your sequences. If you try this option, we strongly encourage you to call
-``qiime quality-filter q-score-joined`` with a higher ``min-quality`` threshold
+``qiime quality-filter q-score`` with a higher ``min-quality`` threshold
 - possibly ``--p-min-quality 20`` or ``--p-min-quality 30`` (see `Bokulich et
 al. 2013`_ for more details). You can then follow the steps in the `OTU
 clustering tutorial`_. After clustering, you will likely want to filter

--- a/source/tutorials/read-joining.rst
+++ b/source/tutorials/read-joining.rst
@@ -103,7 +103,7 @@ with different parameter settings.
 
 .. command-block::
 
-   qiime quality-filter q-score-joined \
+   qiime quality-filter q-score \
      --i-demux demux-joined.qza \
      --o-filtered-sequences demux-joined-filtered.qza \
      --o-filter-stats demux-joined-filter-stats.qza

--- a/source/tutorials/read-joining.rst
+++ b/source/tutorials/read-joining.rst
@@ -96,10 +96,9 @@ Sequence quality control
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Next we’ll apply quality control to our sequences using ``quality-filter
-q-score-joined``. This method is identical to ``quality-filter q-score``,
-except that it operated on joined reads. The parameters to this method have not
-been extensively benchmarked on joined read data, so we recommend experimenting
-with different parameter settings.
+q-score``. The parameters to this method have not been extensively benchmarked
+on joined read data, so we recommend experimenting with different parameter
+settings.
 
 .. command-block::
 


### PR DESCRIPTION
This first commit only changes the method in the command block to see if it fixes the issue. Assuming my understanding is correct and that's where the code that's run is from.
