### PR TITLE
Pin the bibtex extension version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Documentation building requirements.
 Sphinx
 Jinja2
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2.0.0
 lxml
 https://github.com/qiime2/sphinx-ext-qiime2/archive/master.tar.gz


### PR DESCRIPTION
There was a new major release for this extension which has some breaking changes: https://sphinxcontrib-bibtex.readthedocs.io/en/2.0.0/changes.html

See also https://github.com/executablebooks/jupyter-book/issues/1137