### PR TITLE
Changes "preprint" to "paper", updates URL

### DIFF
--- a/source/citation.rst
+++ b/source/citation.rst
@@ -3,7 +3,7 @@ Citing QIIME 2
 
 Please note that almost all QIIME 2 plugins implement methods that were developed independently of the QIIME 2 framework, which should be cited in addition to the QIIME 2 framework itself. This information can be extracted as described below.
 
-If you use QIIME 2 in your research, please cite the following `preprint`_:
+If you use QIIME 2 in your research, please cite the following `paper`_:
 
     Bolyen E, Rideout JR, Dillon MR, Bokulich NA, Abnet CC, Al-Ghalith GA, Alexander H, Alm EJ, Arumugam M, Asnicar F, Bai Y, Bisanz JE, Bittinger K, Brejnrod A, Brislawn CJ, Brown CT, Callahan BJ, Caraballo-Rodríguez AM, Chase J, Cope EK, Da Silva R, Diener C, Dorrestein PC, Douglas GM, Durall DM, Duvallet C, Edwardson CF, Ernst M, Estaki M, Fouquier J, Gauglitz JM, Gibbons SM, Gibson DL, Gonzalez A, Gorlick K, Guo J, Hillmann B, Holmes S, Holste H, Huttenhower C, Huttley GA, Janssen S, Jarmusch AK, Jiang L, Kaehler BD, Kang KB, Keefe CR, Keim P, Kelley ST, Knights D, Koester I, Kosciolek T, Kreps J, Langille MGI, Lee J, Ley R, Liu YX, Loftfield E, Lozupone C, Maher M, Marotz C, Martin BD, McDonald D, McIver LJ, Melnik AV, Metcalf JL, Morgan SC, Morton JT, Naimey AT, Navas-Molina JA, Nothias LF, Orchanian SB, Pearson T, Peoples SL, Petras D, Preuss ML, Pruesse E, Rasmussen LB, Rivers A, Robeson MS, Rosenthal P, Segata N, Shaffer M, Shiffer A, Sinha R, Song SJ, Spear JR, Swafford AD, Thompson LR, Torres PJ, Trinh P, Tripathi A, Turnbaugh PJ, Ul-Hasan S, van der Hooft JJJ, Vargas F, Vázquez-Baeza Y, Vogtmann E, von Hippel M, Walters W, Wan Y, Wang M, Warren J, Weber KC, Williamson CHD, Willis AD, Xu ZZ, Zaneveld JR, Zhang Y, Zhu Q, Knight R, and Caporaso JG. 2019. Reproducible, interactive, scalable and extensible microbiome data science using QIIME 2. Nature Biotechnology 37: 852–857. https://doi.org/10.1038/s41587-019-0209-9
 
@@ -69,7 +69,7 @@ This methods section was adapted from `Pearson et al. 2019`_ (and shortened in t
 * Price MN, Dehal PS, Arkin AP. FastTree 2–approximately maximum‐likelihood trees for large alignments. PLoS ONE. 2010;5:e9490.
 
 
-.. _preprint: https://peerj.com/preprints/27295/
+.. _paper: https://doi.org/10.1038/s41587-019-0209-9
 .. _VSEARCH: https://github.com/torognes/vsearch
 .. _q2-feature-classifier: https://doi.org/10.1186/s40168-018-0470-z
 .. _QIIME 2 forum: https://forum.qiime2.org/


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39198770/122970468-d46abf80-d342-11eb-947d-f67b4b9abe07.png)

Our [citation page](https://docs.qiime2.org/2021.4/citation/) correctly displays the Nature citation, but links to the PeerJ preprint. If this isn't intentional, this PR should fix the inconsistency.

![image](https://user-images.githubusercontent.com/39198770/122971918-6de6a100-d344-11eb-9361-e2d3cb32e312.png)
