### PR TITLE
BUG: q2studio installation instructions - resolving npm install dependency conflicts

### DIFF
--- a/source/interfaces/q2studio.rst
+++ b/source/interfaces/q2studio.rst
@@ -38,7 +38,7 @@ Next we need to install it (both as a Python package, and as a Node.js package):
 
    conda install gevent nodejs -c defaults --override-channels
    pip install .
-   npm install && npm run build
+   npm install --legacy-peer-deps && npm run build
 
 Finally we will be able to launch the interface with:
 


### PR DESCRIPTION
Issue reported via forum: https://forum.qiime2.org/t/instaling-quiime-2-studio-error/19886

Similar issue resolved with the same updates: https://github.com/qiime2/vm-playbooks/commit/f5c2f507d7c479263bf9bdc68aa93a6e894a05ab