### PR TITLE
IMP: updating conda installation code block to separate install and cleanup commands

### DIFF
--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -66,19 +66,19 @@ like for the environment. In this example, we'll name the environment
               From the above tabs, please choose the installation instructions that are appropriate for your platform.
             </p>
          </div>
-         <div id="macOS" class="tab-pane highlight-shell">
+         <div id="macOS" class="tab-pane fade">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-osx-conda.yml
    conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml</pre>
    OPTIONAL CLEANUP
    <pre>rm qiime2-2022.11-py38-osx-conda.yml</pre>
          </div>
-         <div id="linux" class="tab-pane fade highlight-shell">
+         <div id="linux" class="tab-pane fade">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml
    conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml</pre>
    OPTIONAL CLEANUP
    <pre>rm qiime2-2022.11-py38-linux-conda.yml</pre>
          </div>
-         <div id="wsl" class="tab-pane fade highlight-shell">
+         <div id="wsl" class="tab-pane fade">
             These instructions are identical to the Linux (64-bit) instructions
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml
    conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml</pre>

--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -66,24 +66,24 @@ like for the environment. In this example, we'll name the environment
               From the above tabs, please choose the installation instructions that are appropriate for your platform.
             </p>
          </div>
-         <div id="macOS" class="tab-pane fade">
+         <div id="macOS" class="tab-pane highlight-shell">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-osx-conda.yml
-   conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml
-   # OPTIONAL CLEANUP
-   rm qiime2-2022.11-py38-osx-conda.yml</pre>
+   conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml</pre>
+   OPTIONAL CLEANUP
+   <pre>rm qiime2-2022.11-py38-osx-conda.yml</pre>
          </div>
-         <div id="linux" class="tab-pane fade">
+         <div id="linux" class="tab-pane fade highlight-shell">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml
-   conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml
-   # OPTIONAL CLEANUP
-   rm qiime2-2022.11-py38-linux-conda.yml</pre>
+   conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml</pre>
+   OPTIONAL CLEANUP
+   <pre>rm qiime2-2022.11-py38-linux-conda.yml</pre>
          </div>
-         <div id="wsl" class="tab-pane fade">
-            <pre># These instructions are identical to the Linux (64-bit) instructions
-   wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml
-   conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml
-   # OPTIONAL CLEANUP
-   rm qiime2-2022.11-py38-linux-conda.yml</pre>
+         <div id="wsl" class="tab-pane fade highlight-shell">
+            These instructions are identical to the Linux (64-bit) instructions
+            <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml
+   conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml</pre>
+   OPTIONAL CLEANUP
+   <pre>rm qiime2-2022.11-py38-linux-conda.yml</pre>
          </div>
       </div>
    </div>


### PR DESCRIPTION
The code blocks mixed in with text in our install instructions are a bit confusing and can lead to accidental copying of the text in addition to just the install commands. I made some small tweaks to the HTML block that I think will improve readability.

Here is what the install code block per OS **currently** looks like for conda installation:

**OSX**:
<img width="866" alt="Screen Shot 2022-09-13 at 11 24 41 AM" src="https://user-images.githubusercontent.com/54517601/189981136-23a72ca9-a045-451c-9880-5953462b842f.png">
**WSL**:
<img width="842" alt="Screen Shot 2022-09-13 at 11 24 50 AM" src="https://user-images.githubusercontent.com/54517601/189981148-22210899-3750-4ea5-8dc0-d032fe6df18b.png">

And here is what these code blocks will look like (tested and rendered locally) when the text is separated from the actual commands:

**OSX**:
<img width="943" alt="Screen Shot 2022-09-13 at 11 22 11 AM" src="https://user-images.githubusercontent.com/54517601/189981409-d901bd51-ada8-4750-aca1-02c1b08907d2.png">
**WSL**:
<img width="927" alt="Screen Shot 2022-09-13 at 11 22 19 AM" src="https://user-images.githubusercontent.com/54517601/189981433-24de36f7-96cd-4a33-ac95-e2a4a2972c6e.png">

I couldn't find a way to include the copy widget in this block due to the fact that this isn't just a raw code block - it's HTML, which accommodates the multiple panes per OS. If anyone knows of a way to add in the copy widget, please feel free to add that in!