### PR TITLE
imp: adding M1 chip macOS install instructions

### DIFF
--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -78,6 +78,8 @@ like for the environment. In this example, we'll name the environment
    CONDA_SUBDIR=osx-64 conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml
    conda activate qiime2-2022.11
    conda config --env --set subdir osx-64</pre>
+   OPTIONAL CLEANUP
+   <pre>rm qiime2-2022.11-py38-osx-conda.yml</pre>
          </div>
          <div id="linux" class="tab-pane fade">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml

--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -76,7 +76,7 @@ like for the environment. In this example, we'll name the environment
          <div id="M1-macOS" class="tab-pane fade">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-osx-conda.yml
    CONDA_SUBDIR=osx-64 conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml
-   conda activate qiime2-2022.8
+   conda activate qiime2-2022.11
    conda config --env --set subdir osx-64</pre>
          </div>
          <div id="linux" class="tab-pane fade">

--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -56,7 +56,8 @@ like for the environment. In this example, we'll name the environment
    <div class="tabbed">
       <ul class="nav nav-tabs">
          <li class="active"><a data-toggle="tab" href="#instructions">Instructions</a></li>
-         <li><a data-toggle="tab" href="#macOS">macOS/OS X (64-bit)</a></li>
+         <li><a data-toggle="tab" href="#macOS">macOS/OSX (64-bit)</a></li>
+         <li><a data-toggle="tab" href="#M1-macOS">macOS/OSX - M1 chip (64-bit)</a></li>
          <li><a data-toggle="tab" href="#linux">Linux (64-bit)</a></li>
          <li><a data-toggle="tab" href="#wsl">Windows Subsystem for Linux (64-bit)</a></li>
       </ul>
@@ -71,6 +72,12 @@ like for the environment. In this example, we'll name the environment
    conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml</pre>
    OPTIONAL CLEANUP
    <pre>rm qiime2-2022.11-py38-osx-conda.yml</pre>
+         </div>
+         <div id="M1-macOS" class="tab-pane fade">
+            <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-osx-conda.yml
+   CONDA_SUBDIR=osx-64 conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml
+   conda activate qiime2-2022.8
+   conda config --env --set subdir osx-64</pre>
          </div>
          <div id="linux" class="tab-pane fade">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml

--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -56,8 +56,8 @@ like for the environment. In this example, we'll name the environment
    <div class="tabbed">
       <ul class="nav nav-tabs">
          <li class="active"><a data-toggle="tab" href="#instructions">Instructions</a></li>
-         <li><a data-toggle="tab" href="#macOS">macOS/OSX (64-bit)</a></li>
-         <li><a data-toggle="tab" href="#M1-macOS">macOS/OSX - M1 chip (64-bit)</a></li>
+         <li><a data-toggle="tab" href="#macOS">OS X (64-bit)</a></li>
+         <li><a data-toggle="tab" href="#M1-macOS">OS X (M1)</a></li>
          <li><a data-toggle="tab" href="#linux">Linux (64-bit)</a></li>
          <li><a data-toggle="tab" href="#wsl">Windows Subsystem for Linux (64-bit)</a></li>
       </ul>


### PR DESCRIPTION
This PR adds an install tab with instructions for macOS users with an M1 chip.