### PR TITLE
maint: native installation instructions hints

### DIFF
--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -56,10 +56,10 @@ like for the environment. In this example, we'll name the environment
    <div class="tabbed">
       <ul class="nav nav-tabs">
          <li class="active"><a data-toggle="tab" href="#instructions">Instructions</a></li>
-         <li><a data-toggle="tab" href="#macOS">OS X (64-bit)</a></li>
-         <li><a data-toggle="tab" href="#M1-macOS">OS X (M1)</a></li>
-         <li><a data-toggle="tab" href="#linux">Linux (64-bit)</a></li>
-         <li><a data-toggle="tab" href="#wsl">Windows Subsystem for Linux (64-bit)</a></li>
+         <li><a data-toggle="tab" href="#macOS-intel">macOS (Intel) and OS X</a></li>
+         <li><a data-toggle="tab" href="#macOS-apple-silicon">macOS (Apple Silicon)</a></li>
+         <li><a data-toggle="tab" href="#linux">Linux</a></li>
+         <li><a data-toggle="tab" href="#wsl">Windows (via WSL)</a></li>
       </ul>
       <div class="tab-content">
          <div id="instructions" class="tab-pane fade in active">
@@ -67,31 +67,32 @@ like for the environment. In this example, we'll name the environment
               From the above tabs, please choose the installation instructions that are appropriate for your platform.
             </p>
          </div>
-         <div id="macOS" class="tab-pane fade">
+         <div id="macOS-intel" class="tab-pane fade">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-osx-conda.yml
    conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml</pre>
-   OPTIONAL CLEANUP
+   <span>OPTIONAL CLEANUP</span>
    <pre>rm qiime2-2022.11-py38-osx-conda.yml</pre>
          </div>
-         <div id="M1-macOS" class="tab-pane fade">
+         <div id="macOS-apple-silicon" class="tab-pane fade">
+            <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-osx-conda.yml
    CONDA_SUBDIR=osx-64 conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-osx-conda.yml
    conda activate qiime2-2022.11
    conda config --env --set subdir osx-64</pre>
-   OPTIONAL CLEANUP
+   <span>OPTIONAL CLEANUP</span>
    <pre>rm qiime2-2022.11-py38-osx-conda.yml</pre>
          </div>
          <div id="linux" class="tab-pane fade">
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml
    conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml</pre>
-   OPTIONAL CLEANUP
+   <span>OPTIONAL CLEANUP</span>
    <pre>rm qiime2-2022.11-py38-linux-conda.yml</pre>
          </div>
          <div id="wsl" class="tab-pane fade">
-            These instructions are identical to the Linux (64-bit) instructions
+            <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
             <pre>wget https://data.qiime2.org/distro/core/qiime2-2022.11-py38-linux-conda.yml
    conda env create -n qiime2-2022.11 --file qiime2-2022.11-py38-linux-conda.yml</pre>
-   OPTIONAL CLEANUP
+   <span>OPTIONAL CLEANUP</span>
    <pre>rm qiime2-2022.11-py38-linux-conda.yml</pre>
          </div>
       </div>

--- a/source/install/virtual/wsl.rst
+++ b/source/install/virtual/wsl.rst
@@ -6,8 +6,8 @@ you have installed and set up the WSL, install a Linux distribution (step 6 of
 the WSL guide). We suggest the latest stable version of `Ubuntu`_.
 
 Once you have set up the WSL, you can follow the
-:doc:`native conda installation <../native>` guide, choosing the *Windows
-Subsystem for Linux (64-bit)* instructions to finish setting up QIIME 2.
+:doc:`native conda installation <../native>` guide, choosing the *Windows (via
+WSL)* instructions to finish setting up QIIME 2.
 
 Please check out the `QIIME 2 Forum`_ for Community Contributions related to
 setting up and using the WSL.


### PR DESCRIPTION
Updates the native installation docs to not disregard M2 apple silicon users. Also updates the WSL instructions to unify the usage of the WSL acronym from elsewhere in the docs.

---

![image](https://user-images.githubusercontent.com/274668/196729219-9674b322-5426-4c98-9253-a8e6e3b35530.png)

---

![image](https://user-images.githubusercontent.com/274668/195922408-e9b07a7c-3686-441c-b455-a375d690e47c.png)