### PR TITLE
updates notes about classifiers on data resources page

### DIFF
--- a/source/data-resources.rst
+++ b/source/data-resources.rst
@@ -17,6 +17,8 @@ Naive Bayes classifiers trained on:
 
 .. note:: Greengenes2 has succeeded Greengenes 13_8. If you still need to access the outdated 13_8 classifiers, for example to reproduce old results or to compare against new classifiers, you can access them through the older QIIME 2 data resources pages.
 
+.. note:: The Silva classifiers provided here include species-level taxonomy. While Silva annotations do include species, Silva does not curate the species-level taxonomy so this information may be unreliable. In a future version of QIIME 2 we will no longer include species-level information in our Silva taxonomy classifiers. This is discussed on the QIIME 2 Forum `here <https://forum.qiime2.org/t/processing-filtering-and-evaluating-the-silva-database-and-other-reference-sequence-data-with-rescript/15494#heading--second-header>`_ (see *Species-labels: caveat emptor!*).
+
 For Silva 138, please cite the following references if you use any of these pre-trained classifiers:
 
 - Michael S Robeson II, Devon R O'Rourke, Benjamin D Kaehler, Michal Ziemski, Matthew R Dillon, Jeffrey T Foster, Nicholas A Bokulich. RESCRIPt: Reproducible sequence taxonomy reference database management for the masses. bioRxiv 2020.10.05.326504; doi: https://doi.org/10.1101/2020.10.05.326504
@@ -47,6 +49,8 @@ Please cite the following reference, in addition to those listed above, if you u
 - Kaehler, B.D., Bokulich, N.A., McDonald, D. et al. Species abundance information improves sequence taxonomy classification accuracy. Nature Communications 10, 4643 (2019). https://doi.org/10.1038/s41467-019-12669-6
 
 .. _`marker gene db`:
+
+.. note:: The Silva classifiers provided here include species-level taxonomy. While Silva annotations do include species, Silva does not curate the species-level taxonomy so this information may be unreliable. In a future version of QIIME 2 we will no longer include species-level information in our Silva taxonomy classifiers. This is discussed on the QIIME 2 Forum `here <https://forum.qiime2.org/t/processing-filtering-and-evaluating-the-silva-database-and-other-reference-sequence-data-with-rescript/15494#heading--second-header>`_ (see *Species-labels: caveat emptor!*).
 
 Marker gene reference databases
 -------------------------------
@@ -83,6 +87,8 @@ Please cite the following references if you use any of these pre-formatted files
 
 - Michael S Robeson II, Devon R O'Rourke, Benjamin D Kaehler, Michal Ziemski, Matthew R Dillon, Jeffrey T Foster, Nicholas A Bokulich. RESCRIPt: Reproducible sequence taxonomy reference database management for the masses. bioRxiv 2020.10.05.326504; doi: https://doi.org/10.1101/2020.10.05.326504
 - See the `SILVA website <https://www.arb-silva.de/>`_ for the latest citation information for SILVA.
+
+.. note:: The Silva reference files provided here include species-level taxonomy. While Silva annotations do include species, Silva does not curate the species-level taxonomy so this information may be unreliable. In a future version of QIIME 2 we will no longer include species-level information in our Silva reference files. This is discussed on the QIIME 2 Forum `here <https://forum.qiime2.org/t/processing-filtering-and-evaluating-the-silva-database-and-other-reference-sequence-data-with-rescript/15494#heading--second-header>`_ (see *Species-labels: caveat emptor!*).
 
 License Information:
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/data-resources.rst
+++ b/source/data-resources.rst
@@ -15,7 +15,7 @@ Naive Bayes classifiers trained on:
 - `Greengenes2 2022.10 full length sequences <http://ftp.microbio.me/greengenes_release/2022.10/2022.10.backbone.full-length.nb.qza>`_ (MD5: ``98d34227fe67b34f62b464466cca4ffa``)
 - `Greengenes2 2022.10 from 515F/806R region of sequences <http://ftp.microbio.me/greengenes_release/2022.10/2022.10.backbone.v4.nb.qza>`_ (MD5: ``43de361005ae6dcae61b078c0c835021``)
 
-.. note:: Greengenes2 has succeeded Greengenes 13_8. If you still need to access the outdated 13_8 classifiers, for example to reproduce old results or to compare against new classifiers, you can access them through the `QIIME 2 2023.5 data resources <https://docs.qiime2.org/2023.5/data-resources/>`_.
+.. note:: Greengenes2 has succeeded Greengenes 13_8. If you still need to access the outdated 13_8 classifiers, for example to reproduce old results or to compare against new classifiers, you can access them through the older QIIME 2 data resources pages.
 
 For Silva 138, please cite the following references if you use any of these pre-trained classifiers:
 


### PR DESCRIPTION
This PR fixes a broken reference to previous versions of the Greengenes classifiers, and adds a note in several places related to the species-level taxonomy assignments in our classifiers. 

These are two independent commits, so don't need to be squashed before merge. 