### PR TITLE
BUG: usage links using wrong release in base URL

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -406,4 +406,4 @@ linkcheck_timeout = 15
 mathjax_path = ('https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/'
                 'MathJax.js?config=TeX-AMS-MML_HTMLorMML')
 
-html_baseurl = os.environ.get('BASE_URL', 'https://docs.qiime2.org/2021.11/')
+html_baseurl = os.environ.get('BASE_URL', 'https://docs.qiime2.org/2024.5/')


### PR DESCRIPTION
the base URL [that is being used to generate the artifact links](https://github.com/qiime2/sphinx-ext-qiime2/blob/82f9072d6baa07f91466638c1fa0378790df5be4/q2doc/usage/driver.py#L37) in the MP usage tutorial was never updated in the 2022.2 release (PR xref [here](https://github.com/qiime2/docs/pull/527)). the way i've dev bumped subsequent releases has just been a find/replace for n-1 release -> current release, so this got missed for two years. this surfaced because of [this forum post](https://forum.qiime2.org/t/moving-picture-tutorial-ancom-bc-results-broken-links/30480) from Luca, pointing out that the ancombc links don't work (which makes sense b/c that functionality didn't exist in 2021.11). in any case- this shouldn't come up again with my current process, but i'd like to find a way to add some sort of URL validation so that things don't get left behind like this in the future.