### PR TITLE
IMP: install instructions use direct URL for env file

### DIFF
--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -70,32 +70,20 @@ QIIME 2 Amplicon Distribution
             </p>
          </div>
          <div id="amplicon-macOS-intel" class="tab-pane fade">
-            <pre>wget https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.5-py39-osx-conda.yml
-   conda env create -n qiime2-amplicon-2024.5 --file qiime2-amplicon-2024.5-py39-osx-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-amplicon-2024.5-py39-osx-conda.yml</pre>
+            <pre>conda env create -n qiime2-amplicon-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/amplicon/released/qiime2-amplicon-macos-latest-conda.yml</pre>
          </div>
          <div id="amplicon-macOS-apple-silicon" class="tab-pane fade">
             <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
-            <pre>wget https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.5-py39-osx-conda.yml
-   CONDA_SUBDIR=osx-64 conda env create -n qiime2-amplicon-2024.5 --file qiime2-amplicon-2024.5-py39-osx-conda.yml
+            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-amplicon-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/amplicon/released/qiime2-amplicon-macos-latest-conda.yml
    conda activate qiime2-amplicon-2024.5
    conda config --env --set subdir osx-64</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-amplicon-2024.5-py39-osx-conda.yml</pre>
          </div>
          <div id="amplicon-linux" class="tab-pane fade">
-            <pre>wget https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.5-py39-linux-conda.yml
-   conda env create -n qiime2-amplicon-2024.5 --file qiime2-amplicon-2024.5-py39-linux-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-amplicon-2024.5-py39-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-amplicon-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/amplicon/released/qiime2-amplicon-ubuntu-latest-conda.yml</pre>
          </div>
          <div id="amplicon-wsl" class="tab-pane fade">
             <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
-            <pre>wget https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.5-py39-linux-conda.yml
-   conda env create -n qiime2-amplicon-2024.5 --file qiime2-amplicon-2024.5-py39-linux-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-amplicon-2024.5-py39-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-amplicon-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/amplicon/released/qiime2-amplicon-ubuntu-latest-conda.yml</pre>
          </div>
       </div>
    </div>
@@ -120,32 +108,20 @@ QIIME 2 Metagenome Distribution
             </p>
          </div>
          <div id="metagenome-macOS-intel" class="tab-pane fade">
-            <pre>wget https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.5-py39-osx-conda.yml
-   conda env create -n qiime2-metagenome-2024.5 --file qiime2-metagenome-2024.5-py39-osx-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-metagenome-2024.5-py39-osx-conda.yml</pre>
+            <pre>conda env create -n qiime2-metagenome-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/metagenome/released/qiime2-metagenome-macos-latest-conda.yml</pre>
          </div>
          <div id="metagenome-macOS-apple-silicon" class="tab-pane fade">
             <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
-            <pre>wget https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.5-py39-osx-conda.yml
-   CONDA_SUBDIR=osx-64 conda env create -n qiime2-metagenome-2024.5 --file qiime2-metagenome-2024.5-py39-osx-conda.yml
+            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-metagenome-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/metagenome/released/qiime2-metagenome-macos-latest-conda.yml
    conda activate qiime2-metagenome-2024.5
    conda config --env --set subdir osx-64</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-metagenome-2024.5-py39-osx-conda.yml</pre>
          </div>
          <div id="metagenome-linux" class="tab-pane fade">
-            <pre>wget https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.5-py39-linux-conda.yml
-   conda env create -n qiime2-metagenome-2024.5 --file qiime2-metagenome-2024.5-py39-linux-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-metagenome-2024.5-py39-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-metagenome-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/metagenome/released/qiime2-metagenome-ubuntu-latest-conda.yml</pre>
          </div>
          <div id="metagenome-wsl" class="tab-pane fade">
             <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
-            <pre>wget https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.5-py39-linux-conda.yml
-   conda env create -n qiime2-metagenome-2024.5 --file qiime2-metagenome-2024.5-py39-linux-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-metagenome-2024.5-py39-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-metagenome-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/metagenome/released/qiime2-metagenome-ubuntu-latest-conda.yml</pre>
          </div>
       </div>
    </div>
@@ -170,32 +146,20 @@ QIIME 2 Tiny Distribution
             </p>
          </div>
          <div id="tiny-macOS-intel" class="tab-pane fade">
-            <pre>wget https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.5-py39-osx-conda.yml
-   conda env create -n qiime2-tiny-2024.5 --file qiime2-tiny-2024.5-py39-osx-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-tiny-2024.5-py39-osx-conda.yml</pre>
+            <pre>conda env create -n qiime2-tiny-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/tiny/released/qiime2-tiny-macos-latest-conda.yml</pre>
          </div>
          <div id="tiny-macOS-apple-silicon" class="tab-pane fade">
             <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
-            <pre>wget https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.5-py39-osx-conda.yml
-   CONDA_SUBDIR=osx-64 conda env create -n qiime2-tiny-2024.5 --file qiime2-tiny-2024.5-py39-osx-conda.yml
+            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-tiny-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/tiny/released/qiime2-tiny-macos-latest-conda.yml
    conda activate qiime2-tiny-2024.5
    conda config --env --set subdir osx-64</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-tiny-2024.5-py39-osx-conda.yml</pre>
          </div>
          <div id="tiny-linux" class="tab-pane fade">
-            <pre>wget https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.5-py39-linux-conda.yml
-   conda env create -n qiime2-tiny-2024.5 --file qiime2-tiny-2024.5-py39-linux-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-tiny-2024.5-py39-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-tiny-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml</pre>
          </div>
          <div id="tiny-wsl" class="tab-pane fade">
             <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
-            <pre>wget https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.5-py39-linux-conda.yml
-   conda env create -n qiime2-tiny-2024.5 --file qiime2-tiny-2024.5-py39-linux-conda.yml</pre>
-   <span>OPTIONAL CLEANUP</span>
-   <pre>rm qiime2-tiny-2024.5-py39-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-tiny-2024.5 --file https://raw.githubusercontent.com/qiime2/distributions/dev/2024.5/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml</pre>
          </div>
       </div>
    </div>


### PR DESCRIPTION
URLs can now be used in the `-f` param of `conda env create`. Replacing a local file download with a direct raw GH link should reduce the amount of install errors users run into by:

- removing the need to use `wget`
- removing the possibility that users download differing files with the same name (i.e. if a release env gets patched, the file name remains the same) and then aren't using the correct file for install

This adjustment reduces the number of steps required for install and creates a more concise process.