### PR TITLE
revert dev bump to 2025.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: install QIIME 2 amplicon distro
       run: |
         envFile=qiime2-amplicon-ubuntu-latest-conda.yml
-        wget https://raw.githubusercontent.com/qiime2/distributions/dev/2025.4/amplicon/released/$envFile
+        wget https://raw.githubusercontent.com/qiime2/distributions/dev/2024.10/amplicon/released/$envFile
         conda env create -q -p ./test-env --file $envFile
 
     - name: install conda dependencies

--- a/source/conf.py
+++ b/source/conf.py
@@ -406,4 +406,4 @@ linkcheck_timeout = 15
 mathjax_path = ('https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/'
                 'MathJax.js?config=TeX-AMS-MML_HTMLorMML')
 
-html_baseurl = os.environ.get('BASE_URL', 'https://docs.qiime2.org/2025.4/')
+html_baseurl = os.environ.get('BASE_URL', 'https://docs.qiime2.org/2024.10/')

--- a/source/data-resources.rst
+++ b/source/data-resources.rst
@@ -33,10 +33,10 @@ QIIME-compatible SILVA releases (up to release 132), as well as the licensing in
 
 We also provide pre-formatted SILVA reference sequence and taxonomy files here that were processed using `RESCRIPt <https://github.com/bokulich-lab/RESCRIPt>`_. See licensing information below if you use these files.
 
-- `Silva 138 SSURef NR99 full-length sequences <https://data.qiime2.org/2025.4/common/silva-138-99-seqs.qza>`_ (MD5: ``de8886bb2c059b1e8752255d271f3010``)
-- `Silva 138 SSURef NR99 full-length taxonomy <https://data.qiime2.org/2025.4/common/silva-138-99-tax.qza>`_ (MD5: ``f12d5b78bf4b1519721fe52803581c3d``)
-- `Silva 138 SSURef NR99 515F/806R region sequences <https://data.qiime2.org/2025.4/common/silva-138-99-seqs-515-806.qza>`_ (MD5: ``a914837bc3f8964b156a9653e2420d22``)
-- `Silva 138 SSURef NR99 515F/806R region taxonomy <https://data.qiime2.org/2025.4/common/silva-138-99-tax-515-806.qza>`_ (MD5: ``e2c40ae4c60cbf75e24312bb24652f2c``)
+- `Silva 138 SSURef NR99 full-length sequences <https://data.qiime2.org/2024.10/common/silva-138-99-seqs.qza>`_ (MD5: ``de8886bb2c059b1e8752255d271f3010``)
+- `Silva 138 SSURef NR99 full-length taxonomy <https://data.qiime2.org/2024.10/common/silva-138-99-tax.qza>`_ (MD5: ``f12d5b78bf4b1519721fe52803581c3d``)
+- `Silva 138 SSURef NR99 515F/806R region sequences <https://data.qiime2.org/2024.10/common/silva-138-99-seqs-515-806.qza>`_ (MD5: ``a914837bc3f8964b156a9653e2420d22``)
+- `Silva 138 SSURef NR99 515F/806R region taxonomy <https://data.qiime2.org/2024.10/common/silva-138-99-tax-515-806.qza>`_ (MD5: ``e2c40ae4c60cbf75e24312bb24652f2c``)
 
 
 Please cite the following references if you use any of these pre-formatted files:

--- a/source/install/native.rst
+++ b/source/install/native.rst
@@ -34,13 +34,13 @@ Install QIIME 2 within a ``conda`` environment
 ----------------------------------------------
 
 Once you have Miniconda installed, create a ``conda`` environment and install
-the QIIME 2 2025.4 distribution of your choice within the environment.
+the QIIME 2 2024.10 distribution of your choice within the environment.
 We **highly** recommend creating a *new* environment specifically for the
 QIIME 2 distribution and release being installed, as there are many required
 dependencies that you may not want added to an existing environment.
 You can choose whatever name you'd like for the environment.
-In this example, we'll name the environments ``qiime2-<distro>-2025.4``
-to indicate what QIIME 2 release is installed (i.e. ``2025.4``).
+In this example, we'll name the environments ``qiime2-<distro>-2024.10``
+to indicate what QIIME 2 release is installed (i.e. ``2024.10``).
 
 QIIME 2 Amplicon Distribution
 .............................
@@ -62,20 +62,20 @@ QIIME 2 Amplicon Distribution
             </p>
          </div>
          <div id="amplicon-macOS-intel" class="tab-pane fade">
-            <pre>conda env create -n qiime2-amplicon-2025.4 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2025.4-py310-osx-conda.yml</pre>
+            <pre>conda env create -n qiime2-amplicon-2024.10 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.10-py310-osx-conda.yml</pre>
          </div>
          <div id="amplicon-macOS-apple-silicon" class="tab-pane fade">
             <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
-            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-amplicon-2025.4 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2025.4-py310-osx-conda.yml
-   conda activate qiime2-amplicon-2025.4
+            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-amplicon-2024.10 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.10-py310-osx-conda.yml
+   conda activate qiime2-amplicon-2024.10
    conda config --env --set subdir osx-64</pre>
          </div>
          <div id="amplicon-linux" class="tab-pane fade">
-            <pre>conda env create -n qiime2-amplicon-2025.4 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-amplicon-2024.10 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.10-py310-linux-conda.yml</pre>
          </div>
          <div id="amplicon-wsl" class="tab-pane fade">
             <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
-            <pre>conda env create -n qiime2-amplicon-2025.4 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-amplicon-2024.10 --file https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2024.10-py310-linux-conda.yml</pre>
          </div>
       </div>
    </div>
@@ -100,20 +100,20 @@ QIIME 2 Metagenome Distribution
             </p>
          </div>
          <div id="metagenome-macOS-intel" class="tab-pane fade">
-            <pre>conda env create -n qiime2-metagenome-2025.4 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2025.4-py310-osx-conda.yml</pre>
+            <pre>conda env create -n qiime2-metagenome-2024.10 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.10-py310-osx-conda.yml</pre>
          </div>
          <div id="metagenome-macOS-apple-silicon" class="tab-pane fade">
             <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
-            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-metagenome-2025.4 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2025.4-py310-osx-conda.yml
-   conda activate qiime2-metagenome-2025.4
+            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-metagenome-2024.10 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.10-py310-osx-conda.yml
+   conda activate qiime2-metagenome-2024.10
    conda config --env --set subdir osx-64</pre>
          </div>
          <div id="metagenome-linux" class="tab-pane fade">
-            <pre>conda env create -n qiime2-metagenome-2025.4 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-metagenome-2024.10 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.10-py310-linux-conda.yml</pre>
          </div>
          <div id="metagenome-wsl" class="tab-pane fade">
             <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
-            <pre>conda env create -n qiime2-metagenome-2025.4 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-metagenome-2024.10 --file https://data.qiime2.org/distro/metagenome/qiime2-metagenome-2024.10-py310-linux-conda.yml</pre>
          </div>
       </div>
    </div>
@@ -138,20 +138,20 @@ QIIME 2 Pathogenome Distribution
             </p>
          </div>
          <div id="pathogenome-macOS-intel" class="tab-pane fade">
-            <pre>conda env create -n qiime2-pathogenome-2025.4 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2025.4-py310-osx-conda.yml</pre>
+            <pre>conda env create -n qiime2-pathogenome-2024.10 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2024.10-py310-osx-conda.yml</pre>
          </div>
          <div id="pathogenome-macOS-apple-silicon" class="tab-pane fade">
             <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
-            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-pathogenome-2025.4 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2025.4-py310-osx-conda.yml
-   conda activate qiime2-pathogenome-2025.4
+            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-pathogenome-2024.10 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2024.10-py310-osx-conda.yml
+   conda activate qiime2-pathogenome-2024.10
    conda config --env --set subdir osx-64</pre>
          </div>
          <div id="pathogenome-linux" class="tab-pane fade">
-            <pre>conda env create -n qiime2-pathogenome-2025.4 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-pathogenome-2024.10 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2024.10-py310-linux-conda.yml</pre>
          </div>
          <div id="pathogenome-wsl" class="tab-pane fade">
             <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
-            <pre>conda env create -n qiime2-pathogenome-2025.4 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-pathogenome-2024.10 --file https://data.qiime2.org/distro/pathogenome/qiime2-pathogenome-2024.10-py310-linux-conda.yml</pre>
          </div>
       </div>
    </div>
@@ -176,20 +176,20 @@ QIIME 2 Tiny Distribution
             </p>
          </div>
          <div id="tiny-macOS-intel" class="tab-pane fade">
-            <pre>conda env create -n qiime2-tiny-2025.4 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2025.4-py310-osx-conda.yml</pre>
+            <pre>conda env create -n qiime2-tiny-2024.10 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.10-py310-osx-conda.yml</pre>
          </div>
          <div id="tiny-macOS-apple-silicon" class="tab-pane fade">
             <p>These instructions are for users with <a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a> chips (M1, M2, etc), and configures the installation of QIIME 2 in <a href="https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment">Rosetta 2 emulation mode</a>.</p>
-            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-tiny-2025.4 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2025.4-py310-osx-conda.yml
-   conda activate qiime2-tiny-2025.4
+            <pre>CONDA_SUBDIR=osx-64 conda env create -n qiime2-tiny-2024.10 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.10-py310-osx-conda.yml
+   conda activate qiime2-tiny-2024.10
    conda config --env --set subdir osx-64</pre>
          </div>
          <div id="tiny-linux" class="tab-pane fade">
-            <pre>conda env create -n qiime2-tiny-2025.4 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-tiny-2024.10 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.10-py310-linux-conda.yml</pre>
          </div>
          <div id="tiny-wsl" class="tab-pane fade">
             <p>These instructions are identical to the Linux instructions and are intended for users of the <a href="https://learn.microsoft.com/en-us/windows/wsl/about">Windows Subsystem for Linux</a>.</p>
-            <pre>conda env create -n qiime2-tiny-2025.4 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2025.4-py310-linux-conda.yml</pre>
+            <pre>conda env create -n qiime2-tiny-2024.10 --file https://data.qiime2.org/distro/tiny/qiime2-tiny-2024.10-py310-linux-conda.yml</pre>
          </div>
       </div>
    </div>
@@ -202,7 +202,7 @@ Now that you have a QIIME 2 environment, activate it using the environment's nam
 .. command-block::
    :no-exec:
 
-   conda activate qiime2-<distro>-2025.4
+   conda activate qiime2-<distro>-2024.10
 
 To deactivate an environment, run ``conda deactivate``.
 
@@ -241,13 +241,13 @@ of QIIME 2 and one with the newer version.
 -----------------------
 
 If at any point during the analysis the QIIME 2 conda environment is closed
-or deactivated, QIIME 2 2025.4 can be activated (or reactivated) by running
+or deactivated, QIIME 2 2024.10 can be activated (or reactivated) by running
 the following command:
 
 .. command-block::
    :no-exec:
 
-   conda activate qiime2-<distro>-2025.4
+   conda activate qiime2-<distro>-2024.10
 
 To determine the currently active conda environment, run the following
 command and look for the line that starts with "active environment":

--- a/source/install/virtual/docker.rst
+++ b/source/install/virtual/docker.rst
@@ -23,7 +23,7 @@ In a terminal with Docker activated, run:
 .. command-block::
    :no-exec:
 
-   docker pull quay.io/qiime2/<distribution>:2025.4
+   docker pull quay.io/qiime2/<distribution>:2024.10
 
 3. Confirm the installation
 ---------------------------
@@ -33,4 +33,4 @@ Run the following to confirm that the image was successfully fetched.
 .. command-block::
    :no-exec:
 
-   docker run -t -i -v $(pwd):/data quay.io/qiime2/<distribution>:2025.4 qiime
+   docker run -t -i -v $(pwd):/data quay.io/qiime2/<distribution>:2024.10 qiime

--- a/source/tutorials/atacama-soils.rst
+++ b/source/tutorials/atacama-soils.rst
@@ -45,7 +45,7 @@ available as a Google Sheet. This ``sample-metadata.tsv`` file is used
 throughout the rest of the tutorial.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/atacama-soils/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/atacama-soils/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 
@@ -61,15 +61,15 @@ tutorial to further improve the run time.
    mkdir emp-paired-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/atacama-soils/10p/forward.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/atacama-soils/10p/forward.fastq.gz
    :saveas: emp-paired-end-sequences/forward.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/atacama-soils/10p/reverse.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/atacama-soils/10p/reverse.fastq.gz
    :saveas: emp-paired-end-sequences/reverse.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/atacama-soils/10p/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/atacama-soils/10p/barcodes.fastq.gz
    :saveas: emp-paired-end-sequences/barcodes.fastq.gz
 
 .. _`atacama demux`:
@@ -253,4 +253,4 @@ Califf, Cesar Cardona, Audrey Copeland, Will van Treuren, Karen L. Josephson,
 Rob Knight, Jack A. Gilbert, Jay Quade, J. Gregory Caporaso, and Raina M.
 Maier. mSystems May 2017, 2 (3) e00195-16; DOI: 10.1128/mSystems.00195-16.
 
-.. _sample metadata: https://data.qiime2.org/2025.4/tutorials/atacama-soils/sample_metadata
+.. _sample metadata: https://data.qiime2.org/2024.10/tutorials/atacama-soils/sample_metadata

--- a/source/tutorials/chimera.rst
+++ b/source/tutorials/chimera.rst
@@ -19,11 +19,11 @@ Start by creating a directory to work in.
 Next, download the necessary files:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/chimera/atacama-table.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/chimera/atacama-table.qza
    :saveas: atacama-table.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/chimera/atacama-rep-seqs.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/chimera/atacama-rep-seqs.qza
    :saveas: atacama-rep-seqs.qza
 
 Run *de novo* chimera checking

--- a/source/tutorials/exporting.rst
+++ b/source/tutorials/exporting.rst
@@ -17,7 +17,7 @@ Exporting a feature table
 A ``FeatureTable[Frequency]`` artifact will be exported as a `BIOM v2.1.0 formatted file`_.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/exporting/feature-table.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/exporting/feature-table.qza
    :saveas: feature-table.qza
 
 .. command-block::
@@ -32,7 +32,7 @@ Exporting a phylogenetic tree
 A ``Phylogeny[Unrooted]`` artifact will be exported as a `newick formatted file`_.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/exporting/unrooted-tree.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/exporting/unrooted-tree.qza
    :saveas: unrooted-tree.qza
 
 .. command-block::

--- a/source/tutorials/feature-classifier.rst
+++ b/source/tutorials/feature-classifier.rst
@@ -25,11 +25,11 @@ Two elements are required for training the classifier: the reference sequences a
 We will also download the representative sequences from the `Moving Pictures`_ tutorial to test our classifier.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/training-feature-classifiers/85_otus.fasta
+   :url: https://data.qiime2.org/2024.10/tutorials/training-feature-classifiers/85_otus.fasta
    :saveas: 85_otus.fasta
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/training-feature-classifiers/85_otu_taxonomy.txt
+   :url: https://data.qiime2.org/2024.10/tutorials/training-feature-classifiers/85_otu_taxonomy.txt
    :saveas: 85_otu_taxonomy.txt
 
 Next we import these data into QIIME 2 Artifacts. Since the Greengenes reference taxonomy file (:file:`85_otu_taxonomy.txt`) is a tab-separated (TSV) file without a header, we must specify ``HeaderlessTSVTaxonomyFormat`` as the *source format* since the default *source format* requires a header.
@@ -89,7 +89,7 @@ Test the classifier
 Finally, we verify that the classifier works by classifying the representative sequences from the `Moving Pictures`_ tutorial and visualizing the resulting taxonomic assignments.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/training-feature-classifiers/rep-seqs.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/training-feature-classifiers/rep-seqs.qza
    :saveas: rep-seqs.qza
 
 .. command-block::

--- a/source/tutorials/filtering.rst
+++ b/source/tutorials/filtering.rst
@@ -19,23 +19,23 @@ First, create a directory to work in and change to that directory.
 Download the data we'll use in the tutorial. This includes sample metadata, a feature table, and a distance matrix:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/filtering/table.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/filtering/table.qza
    :saveas: table.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/filtering/distance-matrix.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/filtering/distance-matrix.qza
    :saveas: distance-matrix.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/filtering/taxonomy.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/filtering/taxonomy.qza
    :saveas: taxonomy.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/filtering/sequences.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/filtering/sequences.qza
    :saveas: sequences.qza
 
 Filtering feature tables

--- a/source/tutorials/fmt.rst
+++ b/source/tutorials/fmt.rst
@@ -25,7 +25,7 @@ Create a directory to work in called ``qiime2-fmt-tutorial`` and change to that 
 As in the Moving Pictures study, you should begin your analysis by familiarizing yourself with the sample metadata. You can again access the `sample metadata`_ as a Google Spreadsheet. Notice that there are three tabs in this spreadsheet. This first tab (called sample-metadata) contains all of the clinical metadata.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/fmt/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/fmt/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 Next, download the *demultiplexed sequences* that we'll use in this analysis. To learn how to start a QIIME 2 analysis from fastq-formatted sequence data, see the :doc:`importing data tutorial <importing>`. We'll need to download two sets of demultiplexed sequences, each corresponding to one of the sequencing runs.
@@ -38,23 +38,23 @@ In this tutorial we'll work with a small subsample of the complete sequence data
 
 .. download::
    :no-exec:
-   :url: https://data.qiime2.org/2025.4/tutorials/fmt/fmt-tutorial-demux-1-10p.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/fmt/fmt-tutorial-demux-1-10p.qza
    :saveas: fmt-tutorial-demux-1.qza
 
 .. download::
    :no-exec:
-   :url: https://data.qiime2.org/2025.4/tutorials/fmt/fmt-tutorial-demux-2-10p.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/fmt/fmt-tutorial-demux-2-10p.qza
    :saveas: fmt-tutorial-demux-2.qza
 
 1% subsample data
 ~~~~~~~~~~~~~~~~~
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/fmt/fmt-tutorial-demux-1-1p.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/fmt/fmt-tutorial-demux-1-1p.qza
    :saveas: fmt-tutorial-demux-1.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/fmt/fmt-tutorial-demux-2-1p.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/fmt/fmt-tutorial-demux-2-1p.qza
    :saveas: fmt-tutorial-demux-2.qza
 
 Sequence quality control
@@ -185,5 +185,5 @@ Acknowledgements
 The data in this tutorial was initially presented in: Microbiota Transfer Therapy alters gut ecosystem and improves gastrointestinal and autism symptoms: an open-label study. Dae-Wook Kang, James B. Adams, Ann C. Gregory, Thomas Borody, Lauren Chittick, Alessio Fasano, Alexander Khoruts, Elizabeth Geis, Juan Maldonado, Sharon McDonough-Means, Elena L. Pollard, Simon Roux, Michael J. Sadowsky, Karen Schwarzberg Lipson, Matthew B. Sullivan, J. Gregory Caporaso and Rosa Krajmalnik-Brown. Microbiome (2017) 5:10. DOI: 10.1186/s40168-016-0225-7.
 
 .. _DADA2: https://www.ncbi.nlm.nih.gov/pubmed/27214047
-.. _sample metadata: https://data.qiime2.org/2025.4/tutorials/fmt/sample_metadata
+.. _sample metadata: https://data.qiime2.org/2024.10/tutorials/fmt/sample_metadata
 .. _Fecal Microbiome Transplant study: http://microbiomejournal.biomedcentral.com/articles/10.1186/s40168-016-0225-7

--- a/source/tutorials/importing.rst
+++ b/source/tutorials/importing.rst
@@ -62,11 +62,11 @@ Obtaining example data
    mkdir emp-single-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
    :saveas: emp-single-end-sequences/barcodes.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
    :saveas: emp-single-end-sequences/sequences.fastq.gz
 
 Importing data
@@ -105,15 +105,15 @@ Obtaining example data
    mkdir emp-paired-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/atacama-soils/1p/forward.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/atacama-soils/1p/forward.fastq.gz
    :saveas: emp-paired-end-sequences/forward.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/atacama-soils/1p/reverse.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/atacama-soils/1p/reverse.fastq.gz
    :saveas: emp-paired-end-sequences/reverse.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/atacama-soils/1p/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/atacama-soils/1p/barcodes.fastq.gz
    :saveas: emp-paired-end-sequences/barcodes.fastq.gz
 
 Importing data
@@ -147,7 +147,7 @@ Obtaining example data
    mkdir muxed-se-barcode-in-seq
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/muxed-se-barcode-in-seq.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/muxed-se-barcode-in-seq.fastq.gz
    :saveas: muxed-se-barcode-in-seq/sequences.fastq.gz
 
 Importing data
@@ -192,11 +192,11 @@ Obtaining example data
    mkdir muxed-pe-barcode-in-seq
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/muxed-pe-barcode-in-seq/forward.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/muxed-pe-barcode-in-seq/forward.fastq.gz
    :saveas: muxed-pe-barcode-in-seq/forward.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/muxed-pe-barcode-in-seq/reverse.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/muxed-pe-barcode-in-seq/reverse.fastq.gz
    :saveas: muxed-pe-barcode-in-seq/reverse.fastq.gz
 
 Importing data
@@ -229,7 +229,7 @@ Obtaining example data
 ``````````````````````
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/casava-18-single-end-demultiplexed.zip
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/casava-18-single-end-demultiplexed.zip
    :saveas: casava-18-single-end-demultiplexed.zip
 
 .. command-block::
@@ -266,7 +266,7 @@ Obtaining example data
 ``````````````````````
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/casava-18-paired-end-demultiplexed.zip
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/casava-18-paired-end-demultiplexed.zip
    :saveas: casava-18-paired-end-demultiplexed.zip
 
 .. command-block::
@@ -324,11 +324,11 @@ SingleEndFastqManifestPhred33V2
 In this variant of the fastq manifest format, the read directions must all either be forward or reverse. This format assumes that the `PHRED offset`_ used for the positional quality scores in all of the ``fastq.gz`` / ``fastq`` files is 33.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/se-33.zip
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/se-33.zip
    :saveas: se-33.zip
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/se-33-manifest
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/se-33-manifest
    :saveas: se-33-manifest
 
 .. command-block::
@@ -358,11 +358,11 @@ PairedEndFastqManifestPhred64V2
 In this variant of the fastq manifest format, there must be forward and reverse read ``fastq.gz`` / ``fastq`` files for each sample ID. This format assumes that the `PHRED offset`_ used for the positional quality scores in all of the ``fastq.gz`` / ``fastq`` files is 64. During import, QIIME 2 will convert the PHRED 64 encoded quality scores to PHRED 33 encoded quality scores. This conversion will be slow, but will only happen one time.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/pe-64.zip
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/pe-64.zip
    :saveas: pe-64.zip
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/pe-64-manifest
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/pe-64-manifest
    :saveas: pe-64-manifest
 
 .. command-block::
@@ -396,7 +396,7 @@ Obtaining example data
 **********************
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/sequences.fna
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/sequences.fna
    :saveas: sequences.fna
 
 Importing data
@@ -421,7 +421,7 @@ Obtaining example data
 **********************
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/aligned-sequences.fna
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/aligned-sequences.fna
    :saveas: aligned-sequences.fna
 
 Importing data
@@ -453,7 +453,7 @@ Obtaining example data
 ``````````````````````
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/feature-table-v100.biom
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/feature-table-v100.biom
    :saveas: feature-table-v100.biom
 
 Importing data
@@ -479,7 +479,7 @@ Obtaining example data
 ``````````````````````
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/feature-table-v210.biom
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/feature-table-v210.biom
    :saveas: feature-table-v210.biom
 
 Importing data
@@ -505,7 +505,7 @@ Obtaining example data
 **********************
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/importing/unrooted-tree.tre
+   :url: https://data.qiime2.org/2024.10/tutorials/importing/unrooted-tree.tre
    :saveas: unrooted-tree.tre
 
 Importing data

--- a/source/tutorials/longitudinal.rst
+++ b/source/tutorials/longitudinal.rst
@@ -22,15 +22,15 @@ In the examples below, we use data from the `ECAM study`_, a longitudinal study 
    cd longitudinal-tutorial
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/longitudinal/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/longitudinal/sample_metadata.tsv
    :saveas: ecam-sample-metadata.tsv
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/longitudinal/ecam_shannon.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/longitudinal/ecam_shannon.qza
    :saveas: shannon.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/longitudinal/unweighted_unifrac_distance_matrix.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/longitudinal/unweighted_unifrac_distance_matrix.qza
    :saveas: unweighted_unifrac_distance_matrix.qza
 
 
@@ -209,7 +209,7 @@ Within microbial communities, microbial populations do not exist in isolation bu
 First let's download a feature table to test. Here we will test genus-level taxa that exhibit a relative abundance > 0.1% in more than 15% of the total samples.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/longitudinal/ecam_table_taxa.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/longitudinal/ecam_table_taxa.qza
    :saveas: ecam-table-taxa.qza
 
 Now we are ready run NMIT. The output of this command is a distance matrix that we can pass to other QIIME2 commands for significance testing and visualization.
@@ -264,7 +264,7 @@ This pipeline identifies features that are predictive of a numeric metadata colu
 Let's test this out on the ECAM dataset. First download a table to work with:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/longitudinal/ecam_table_maturity.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/longitudinal/ecam_table_maturity.qza
    :saveas: ecam-table.qza
 
 .. command-block::

--- a/source/tutorials/metadata.rst
+++ b/source/tutorials/metadata.rst
@@ -191,7 +191,7 @@ To get started with understanding sample metadata files, download an example TSV
    cd qiime2-metadata-tutorial
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 Since this is a TSV file, it can be opened and edited in a variety of applications, including text editors, Microsoft Excel, and Google Sheets (e.g. if you plan to validate your metadata with Keemei_).
@@ -216,7 +216,7 @@ In addition to TSV metadata files, QIIME 2 also supports viewing some kinds of a
 To get started with understanding artifacts as metadata, first download an example artifact:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/metadata/faith_pd_vector.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/metadata/faith_pd_vector.qza
    :saveas: faith_pd_vector.qza
 
 To view this artifact as metadata, simply pass it in to any method or visualizer that expects to see metadata (e.g. ``metadata tabulate`` or ``emperor plot``):
@@ -253,7 +253,7 @@ The resulting metadata after the merge will contain the intersection of the iden
 Metadata merging is supported anywhere that metadata is accepted in QIIME 2. For example, it might be interesting to color an Emperor plot based on the study metadata, or sample alpha diversity. This can be accomplished by providing both the sample metadata file *and* the ``SampleData[AlphaDiversity]`` artifact:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/metadata/unweighted_unifrac_pcoa_results.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/metadata/unweighted_unifrac_pcoa_results.qza
    :saveas: unweighted_unifrac_pcoa_results.qza
 
 .. command-block::
@@ -277,11 +277,11 @@ Metadata in QIIME 2 can be applied to sample or features --- so far we have only
 To get started with feature metadata, first download the example files:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/metadata/rep-seqs.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/metadata/rep-seqs.qza
    :saveas: rep-seqs.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/metadata/taxonomy.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/metadata/taxonomy.qza
    :saveas: taxonomy.qza
 
 We have downloaded a ``FeatureData[Sequence]`` file (``rep-seqs.qza``) and a ``FeatureData[Taxonomy]`` file (``taxonomy.qza``). We can merge (and ``tabulate``) these files to associate the representative sequences with their taxonomic annotations:
@@ -312,6 +312,6 @@ Finally, there are export options available in the visualizations produced from 
 .. _`cual-id`: http://msystems.asm.org/content/1/1/e00010-15
 .. _`Phylip`: http://evolution.genetics.washington.edu/phylip.html
 .. _`Python csv module`: https://docs.python.org/3/library/csv.html
-.. _`evenness vector`: https://docs.qiime2.org/2025.4/data/tutorials/moving-pictures/core-metrics-results/evenness_vector.qza
-.. _`feature table artifact`: https://docs.qiime2.org/2025.4/data/tutorials/moving-pictures/table.qza
-.. _`QIIME 2 Utilities`: https://docs.qiime2.org/2025.4/tutorials/utilities
+.. _`evenness vector`: https://docs.qiime2.org/2024.10/data/tutorials/moving-pictures/core-metrics-results/evenness_vector.qza
+.. _`feature table artifact`: https://docs.qiime2.org/2024.10/data/tutorials/moving-pictures/table.qza
+.. _`QIIME 2 Utilities`: https://docs.qiime2.org/2024.10/tutorials/utilities

--- a/source/tutorials/moving-pictures-usage.rst
+++ b/source/tutorials/moving-pictures-usage.rst
@@ -48,7 +48,7 @@ tab-separated text and save it in the file ``sample-metadata.tsv``. This
        from urllib import request
        from qiime2 import Metadata
        fp, _ = request.urlretrieve(
-           'https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata.tsv',
+           'https://data.qiime2.org/2024.10/tutorials/moving-pictures/sample_metadata.tsv',
        )
 
        return Metadata.load(fp)
@@ -84,7 +84,7 @@ commands will run quickly.
        from q2_types.multiplexed_sequences._formats import EMPSingleEndDirFmt
        from q2_types.per_sample_sequences import FastqGzFormat
 
-       base_url = 'https://data.qiime2.org/2025.4/tutorials/moving-pictures/'
+       base_url = 'https://data.qiime2.org/2024.10/tutorials/moving-pictures/'
        bc_url = base_url + 'emp-single-end-sequences/barcodes.fastq.gz'
        seqs_url = base_url + 'emp-single-end-sequences/sequences.fastq.gz'
 
@@ -938,7 +938,7 @@ level (i.e. level 6 of the Greengenes taxonomy).
 .. g__Parabacteroides (enriched), g__Paraprevotella (depleted)
 .. We see more differentially abundant features in the original compared to the collapsed table, which is reasonable since we are collapsing at the genus level and thus losing some resolution. However, collapsing at level 6 may allow us to investigate patterns that aren't present when looking at ASVs.
 
-.. _sample metadata: https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata
+.. _sample metadata: https://data.qiime2.org/2024.10/tutorials/moving-pictures/sample_metadata
 .. _Keemei: https://keemei.qiime2.org
 .. _DADA2: https://www.ncbi.nlm.nih.gov/pubmed/27214047
 .. _Illumina Overview Tutorial: http://nbviewer.jupyter.org/github/biocore/qiime/blob/1.9.1/examples/ipynb/illumina_overview_tutorial.ipynb

--- a/source/tutorials/moving-pictures.rst
+++ b/source/tutorials/moving-pictures.rst
@@ -24,7 +24,7 @@ Sample metadata
 Before starting the analysis, explore the sample metadata to familiarize yourself with the samples used in this study. The `sample metadata`_ is available as a Google Sheet. You can download this file as tab-separated text by selecting ``File`` > ``Download as`` > ``Tab-separated values``. Alternatively, the following command will download the sample metadata as tab-separated text and save it in the file ``sample-metadata.tsv``. This ``sample-metadata.tsv`` file is used throughout the rest of the tutorial.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 .. tip:: `Keemei`_ is a Google Sheets add-on for validating sample metadata. Validation of sample metadata is important before beginning any analysis. Try installing Keemei following the instructions on its website, and then validate the sample metadata spreadsheet linked above. The spreadsheet also includes a sheet with some invalid data to try out with Keemei.
@@ -41,11 +41,11 @@ Download the sequence reads that we'll use in this analysis. In this tutorial we
    mkdir emp-single-end-sequences
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
    :saveas: emp-single-end-sequences/barcodes.fastq.gz
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
    :saveas: emp-single-end-sequences/sequences.fastq.gz
 
 All data that is used as input to QIIME 2 is in form of QIIME 2 artifacts, which contain information about the type of data and the source of the data. So, the first thing we need to do is import these sequence data files into a QIIME 2 artifact.
@@ -488,7 +488,7 @@ We're also often interested in performing a differential abundance test at a spe
 .. g__Parabacteroides (enriched), g__Paraprevotella (depleted)
 .. We see more differentially abundant features in the original compared to the collapsed table, which is reasonable since we are collapsing at the genus level and thus losing some resolution. However, collapsing at level 6 may allow us to investigate patterns that aren't present when looking at ASVs.
 
-.. _sample metadata: https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata
+.. _sample metadata: https://data.qiime2.org/2024.10/tutorials/moving-pictures/sample_metadata
 .. _Keemei: https://keemei.qiime2.org
 .. _DADA2: https://www.ncbi.nlm.nih.gov/pubmed/27214047
 .. _Illumina Overview Tutorial: http://nbviewer.jupyter.org/github/biocore/qiime/blob/1.9.1/examples/ipynb/illumina_overview_tutorial.ipynb

--- a/source/tutorials/otu-clustering.rst
+++ b/source/tutorials/otu-clustering.rst
@@ -41,11 +41,11 @@ Start by creating a directory to work in.
 Next, download the necessary files:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/otu-clustering/seqs.fna
+   :url: https://data.qiime2.org/2024.10/tutorials/otu-clustering/seqs.fna
    :saveas: seqs.fna
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/otu-clustering/85_otus.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/otu-clustering/85_otus.qza
    :saveas: 85_otus.qza
 
 Dereplicating a ``SampleData[Sequences]`` artifact

--- a/source/tutorials/overview.rst
+++ b/source/tutorials/overview.rst
@@ -278,8 +278,8 @@ Now go forth an have fun! 💃
 .. _q2-phylogeny tutorial: https://forum.qiime2.org/t/q2-phylogeny-community-tutorial/4455
 .. _q2-fragment-insertion tutorial: https://library.qiime2.org/plugins/q2-fragment-insertion/16/
 .. _diversity metrics: https://forum.qiime2.org/t/alpha-and-beta-diversity-explanations-and-commands/2282
-.. _q2-feature-table: https://docs.qiime2.org/2025.4/plugins/available/feature-table/
-.. _many different useful actions: https://docs.qiime2.org/2025.4/plugins/available/diversity/
+.. _q2-feature-table: https://docs.qiime2.org/2024.10/plugins/available/feature-table/
+.. _many different useful actions: https://docs.qiime2.org/2024.10/plugins/available/diversity/
 .. _Principal coordinates analysis: https://mb3is.megx.net/gustame/dissimilarity-based-methods/principal-coordinates-analysis
 .. _longitudinal experiments: https://en.wikipedia.org/wiki/Longitudinal_study
 .. _predict cancer susceptibility: https://dx.doi.org/10.1128%2FmSphere.00001-15

--- a/source/tutorials/pd-mice.rst
+++ b/source/tutorials/pd-mice.rst
@@ -105,7 +105,7 @@ Even though the mouse ID looks like a number, we will specify that it is categor
 The metadata is available as a `Google Sheet`_, or you can download it directly and save it as a TSV (tab-separated values) file.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/sample_metadata.tsv
    :saveas: metadata.tsv
 
 The sample metadata will be used throughout the tutorial. Let's run our first QIIME 2 command, to summarize and explore the metadata.
@@ -130,11 +130,11 @@ We will import the sequences as ``SampleData[SequencesWithQuality]``, which is t
 Let's start by downloading the manifest and corresponding sequences.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/manifest
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/manifest
    :saveas: manifest.tsv
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/demultiplexed_seqs.zip
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/demultiplexed_seqs.zip
    :saveas: demultiplexed_seqs.zip
 
 You'll need to unzip sequence archive you just downloaded:
@@ -693,15 +693,15 @@ If you feel that these samples are not typical stool samples, it is possible to,
 Start by downloading the stool data, along with the 99% Greengene 13_8 reference data.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/ref_seqs_v4.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/ref_seqs_v4.qza
    :saveas: ref_seqs_v4.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/ref_tax.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/ref_tax.qza
    :saveas: ref_tax.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/animal_distal_gut.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/animal_distal_gut.qza
    :saveas: animal_distal_gut.qza
 
 Next retrain the classifier.
@@ -943,7 +943,7 @@ This suggests that there is a genotype-specific effect on the microbiome of mice
 .. _PERMANOVA: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1442-9993.2001.01070.pp.x
 .. _This classifier works: https://doi.org/10.1186/s40168-018-0470-z
 .. _ANCOM-BC paper: https://pubmed.ncbi.nlm.nih.gov/32665548/
-.. _Google Sheet: https://data.qiime2.org/2025.4/tutorials/pd-mice/sample_metadata
+.. _Google Sheet: https://data.qiime2.org/2024.10/tutorials/pd-mice/sample_metadata
 .. _permdisp: https://www.ncbi.nlm.nih.gov/pubmed/16706913
 .. _volcano plot: https://en.wikipedia.org/wiki/Volcano_plot_(statistics)
 .. _confusion matrix: https://en.wikipedia.org/wiki/Confusion_matrix

--- a/source/tutorials/phylogeny.rst
+++ b/source/tutorials/phylogeny.rst
@@ -71,7 +71,7 @@ Let's start by creating a directory to work in:
 Next, download the data:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/phylogeny/rep-seqs.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/phylogeny/rep-seqs.qza
    :saveas: rep-seqs.qza
 
 **Run MAFFT**

--- a/source/tutorials/qiime2-for-experienced-microbiome-researchers.rst
+++ b/source/tutorials/qiime2-for-experienced-microbiome-researchers.rst
@@ -44,7 +44,7 @@ Alternatively, you can also unzip your artifact directly (``unzip -k file.qza``)
 
 **Pro-tip #2: the QIIME 2 command line interface tools are slow because they have to unzip and re-zip the data contained in the artifacts each time you call them.**
 If you need to process your data more interactively, you might want to use the Python API - it is much faster since objects can be simply stored in memory.
-You can learn more about the different `QIIME 2 interfaces <https://docs.qiime2.org/2025.4/interfaces/>`__.
+You can learn more about the different `QIIME 2 interfaces <https://docs.qiime2.org/2024.10/interfaces/>`__.
 
 Data processing steps
 ---------------------

--- a/source/tutorials/quality-control.rst
+++ b/source/tutorials/quality-control.rst
@@ -16,23 +16,23 @@ We will download and create several files, so first create a working directory.
 Let's download some example data and get started.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/quality-control/query-seqs.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/quality-control/query-seqs.qza
    :saveas: query-seqs.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/quality-control/reference-seqs.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/quality-control/reference-seqs.qza
    :saveas: reference-seqs.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/quality-control/query-table.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/quality-control/query-table.qza
    :saveas: query-table.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/quality-control/qc-mock-3-expected.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/quality-control/qc-mock-3-expected.qza
    :saveas: qc-mock-3-expected.qza
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/quality-control/qc-mock-3-observed.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/quality-control/qc-mock-3-observed.qza
    :saveas: qc-mock-3-observed.qza
 
 

--- a/source/tutorials/read-joining.rst
+++ b/source/tutorials/read-joining.rst
@@ -40,7 +40,7 @@ artifact, which contains the demultiplexed reads from the :doc:`Atacama soil
 microbiome tutorial <atacama-soils>`.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/read-joining/atacama-seqs.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/read-joining/atacama-seqs.qza
    :saveas: demux.qza
 
 Joining reads
@@ -166,7 +166,7 @@ First, download the following demultiplexed and joined read data, which
 has been joined on a per-sample basis with ``fastq-join``.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/read-joining/fj-joined.zip
+   :url: https://data.qiime2.org/2024.10/tutorials/read-joining/fj-joined.zip
    :saveas: fj-joined.zip
 
 Unzip this file as follows:

--- a/source/tutorials/sample-classifier.rst
+++ b/source/tutorials/sample-classifier.rst
@@ -23,11 +23,11 @@ Predicting categorical sample data
 Supervised learning classifiers predict the categorical metadata classes of unlabeled samples by learning the composition of labeled training samples. For example, we may use a classifier to diagnose or predict disease susceptibility based on stool microbiome composition, or predict sample type as a function of the sequence variants, microbial taxa, or metabolites detected in a sample. In this tutorial, we will use the :doc:`moving pictures tutorial data <moving-pictures>` to train a classifier that predicts the body site from which a sample was collected. Download the feature table and sample metadata with the following links:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/moving-pictures/sample_metadata.tsv
    :saveas: moving-pictures-sample-metadata.tsv
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/sample-classifier/moving-pictures-table.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/sample-classifier/moving-pictures-table.qza
    :saveas: moving-pictures-table.qza
 
 Next, we will train and test a classifier that predicts which body site a sample originated from based on its microbial composition. We will do so using the ``classify-samples`` pipeline, which performs a series of steps under the hood:
@@ -181,11 +181,11 @@ Predicting continuous (i.e., numerical) sample data
 Supervised learning regressors predict continuous metadata values of unlabeled samples by learning the composition of labeled training samples. For example, we may use a regressor to predict the abundance of a metabolite that will be produced by a microbial community, or a sample's pH,  temperature, or altitude as a function of the sequence variants, microbial taxa, or metabolites detected in a sample. In this tutorial, we will use the `ECAM study`_, a longitudinal cohort study of microbiome development in U.S. infants. Download the feature table and sample metadata with the following links:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/longitudinal/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/longitudinal/sample_metadata.tsv
    :saveas: ecam-metadata.tsv
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/longitudinal/ecam_table_maturity.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/longitudinal/ecam_table_maturity.qza
    :saveas: ecam-table.qza
 
 Next, we will train a regressor to predict an infant's age based on its microbiota composition, using the ``regress-samples`` pipeline.

--- a/source/tutorials/utilities.rst
+++ b/source/tutorials/utilities.rst
@@ -25,7 +25,7 @@ functionality! First, we will take a look at the taxonomic bar charts from the
 :doc:`PD Mice Tutorial <pd-mice>`:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/utilities/taxa-barplot.qzv
+   :url: https://data.qiime2.org/2024.10/tutorials/utilities/taxa-barplot.qzv
    :saveas: taxa-barplot.qzv
 
 Retrieving Citations
@@ -100,7 +100,7 @@ Oftentimes we need to verify the ``type`` and ``uuid`` of an Artifact. We can us
 let's get some data to look at:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/utilities/faith-pd-vector.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/utilities/faith-pd-vector.qza
    :saveas: faith-pd-vector.qza
 
 Now that we have data, we can learn more about the file:
@@ -140,7 +140,7 @@ are in the file?
 We can demonstrate this by first downloading some sample metadata:
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/sample_metadata.tsv
    :saveas: sample-metadata.tsv
 
 Then, we can run the ``qiime tools inspect-metadata`` command:
@@ -160,7 +160,7 @@ This tool can be very helpful for learning about Metadata column names for
 files that are *viewable* as Metadata.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/utilities/jaccard-pcoa.qza
+   :url: https://data.qiime2.org/2024.10/tutorials/utilities/jaccard-pcoa.qza
    :saveas: jaccard-pcoa.qza
 
 The file we just downloaded is a Jaccard PCoA (from the
@@ -190,7 +190,7 @@ metadata used in the **Inspect Metadata** section, so you can skip this step if 
 already downloaded the ``sample_metadata.tsv`` file from above.
 
 .. download::
-   :url: https://data.qiime2.org/2025.4/tutorials/pd-mice/sample_metadata.tsv
+   :url: https://data.qiime2.org/2024.10/tutorials/pd-mice/sample_metadata.tsv
    :saveas: sample_metadata.tsv
 
 In this example, we will cast the ``days_post_transplant`` column from ``numeric`` to


### PR DESCRIPTION
Reverts qiime2/docs#593. This is no longer needed as we're transitioning to the [new docs](https://amplicon-docs.qiime2.org) for 2025.4. 